### PR TITLE
Update help url

### DIFF
--- a/omaha/client/help_url_builder.cc
+++ b/omaha/client/help_url_builder.cc
@@ -86,6 +86,8 @@ HRESULT HelpUrlBuilder::BuildUrl(const std::vector<AppResult>& app_results,
     return hr;
   }
 
+  *help_url = _T("https://support.brave.com/");
+
   return S_OK;
 }
 


### PR DESCRIPTION
Set support.brave.com as a help url.

Issue https://github.com/brave/brave-browser/issues/1585