### PR TITLE
[NOT FOR MERGE] Example for Dev channel standalone installer

### DIFF
--- a/omaha/standalone/manifests/{CB2150F2-595F-4633-891A-E39720CE0531}.gup
+++ b/omaha/standalone/manifests/{CB2150F2-595F-4633-891A-E39720CE0531}.gup
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response protocol="3.0">
+  <app appid="{CB2150F2-595F-4633-891A-E39720CE0531}" status="ok">
+    <updatecheck status="ok">
+      <urls>
+        <url codebase="http://dl.google.com/foo/${INSTALLER_VERSION}/"/>
+      </urls>
+      <manifest>
+        <packages>
+          <package name="BraveBrowserDevSetup.exe" hash_sha256="${INSTALLER_HASH_SHA256}" size="${INSTALLER_SIZE}" required="true"/>
+        </packages>
+        <actions>
+          <action event="install" run="BraveBrowserDevSetup.exe" arguments="--chrome-dev" needsadmin="true"/>
+        </actions>
+       </manifest>
+    </updatecheck>
+  </app>
+</response>

--- a/omaha/standalone/standalone_installers.txt
+++ b/omaha/standalone/standalone_installers.txt
@@ -23,3 +23,4 @@
 # Not a real installer.
 ('Save Arguments', 'SaveArgumentsStandaloneInstaller', [('0.1.2.0', '$STAGING_DIR/unittest_support/SaveArguments.exe', '{7DD1EF7B-D075-47c0-BD51-F624ED87CCF0}')], 'SaveArgumentsStandaloneEnterprise', '', '/silentuninstall', True, '', '')
 ('Bundle_Foo_Argument', 'Bundle_Foo_Argument_StandaloneInstaller', [('0.1.2.0', '$STAGING_DIR/unittest_support/SaveArguments.exe', '{7DD1EF7B-D075-47c0-BD51-F624ED87CCF0}'), ('1.0.101.0', '$STAGING_DIR/unittest_support/test_foo_v1.0.101.0.msi', '{D6B08267-B440-4C85-9F79-E195E80D9937}')], None, None, None, False, '', '')
+('Brave Browser Dev', 'BraveBrowserDevSetup', [('69.0.54.0', '$STAGING_DIR/brave_installer_69_0_54_0.exe', '{CB2150F2-595F-4633-891A-E39720CE0531}')], None, None, None, False, '', '')


### PR DESCRIPTION
This is example code for creating omaha standalone installer.

Below is the step for creating standalone installer of dev 69.0.54.0.

1. Create manifest file `./omaha/standalone/manifests/{CB2150F2-595F-4633-891A-E39720CE0531}.gup` for Dev channel app.
    * Make sure `--chrome-dev` is used in this case
2. Modify `/omaha/standalone/standalone_installers.txt`
    * Add installer description
    * Specify silent installer location. In this case, I copied it to `./staging/`.
3. Build with `hammer MODE=all --all`
    * `./scons-out/opt-win/Test_Installers/UNOFFICIAL_BraveBrowserDevSetup.exe` will be created.
4. Tagging above file
    * `ApplyTag.exe ./UNOFFICIAL_BraveBrowserDevSetup.exe BraveBrowserStandaloneDevSetup.exe "appguid={CB2150F2-595F-4633-891A-E39720CE0531}&appname=Brave-Browser-Dev&needsadmin=prefers&lang=en&ap=x64-dev"
`
5. Run `BraveBrowserStandaloneDevSetup.exe`
