### PR TITLE
Make omaha build w/o admin priv

### DIFF
--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -746,7 +746,7 @@ _official_installers_dirs = [
     ]
 
 _extra_dirs = [
-    'enterprise',
+    #'enterprise',
     'standalone',
     ]
 


### PR DESCRIPTION
It turns out that enterprise module only needs admin priv.
Brave doesn't used it. So it is excluded from build dir list.

Close https://github.com/brave/brave-browser/issues/1988