### PR TITLE
Introduce silent tag for silent installer

### DIFF
--- a/build_omaha.py
+++ b/build_omaha.py
@@ -121,7 +121,7 @@ def Tagging(args, omaha_dir, debug):
   tag = tag.replace("TAG_APP_NAME", args.tag_app_name[0])
   tag = tag.replace("TAG_AP", args.tag_ap[0])
 
-  silent_tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&lang=en&ap=TAG_AP'
+  silent_tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&lang=en&ap=TAG_AP&silent'
   silent_tag = silent_tag.replace("TAG_ADMIN", 'False')
   silent_tag = silent_tag.replace("APP_GUID", args.guid[0])
   silent_tag = silent_tag.replace("TAG_APP_NAME", args.tag_app_name[0])

--- a/omaha/mi_exe_stub/mi.cc
+++ b/omaha/mi_exe_stub/mi.cc
@@ -212,10 +212,32 @@ class MetaInstaller {
           HandleError(hr);
           return hr;
         }
-        SafeCStringAppendCmdLine(&command_line, _T(" /%s %s /%s"),
-                                 kCmdLineInstallSource,
-                                 kCmdLineInstallSource_TaggedMetainstaller,
-                                 kCmdLineInstall);
+
+        const CString original_tag(tag.get());
+        CString silent_tag;
+        silent_tag.Format(_T("&%s"), kCmdLineSilent);
+        const int silent_tag_len = silent_tag.GetLength();
+        // If tag has silent tag, append \silent \install to command line.
+        // Also silent tag is removed from tag list and assign it to |tag|
+        // buffer again. silent tag isn't recognized by brave updater.
+        if (original_tag.Right(silent_tag_len).CompareNoCase(silent_tag) == 0) {
+          const CString revised_tag =
+              original_tag.Left(original_tag.GetLength() - silent_tag_len);
+          const int revised_tag_len = revised_tag.GetLength();
+          char *new_tag_buffer = new char[revised_tag_len + 1];
+          strncpy(new_tag_buffer, tag.get(), revised_tag_len);
+          new_tag_buffer[revised_tag_len] = NULL;
+          tag.reset(new_tag_buffer);
+
+          SafeCStringAppendCmdLine(&command_line, _T(" /%s /%s"),
+                                   kCmdLineSilent,
+                                   kCmdLineInstall);
+        } else {
+          SafeCStringAppendCmdLine(&command_line, _T(" /%s %s /%s"),
+                                   kCmdLineInstallSource,
+                                   kCmdLineInstallSource_TaggedMetainstaller,
+                                   kCmdLineInstall);
+        }
       } else {
         SafeCStringAppendCmdLine(&command_line, _T(" %s"), cmd_line_);
 


### PR DESCRIPTION
When silent tag is added in tag list, "/silent /install" is added to
command line by metainstaller.
silent tag should be added at last of tag list.

Silent installer only launches browser window when install is finished.

Fix https://github.com/brave/brave-browser/issues/2356