### PR TITLE
Fix signing server error

### DIFF
--- a/omaha/hammer-brave.bat
+++ b/omaha/hammer-brave.bat
@@ -35,7 +35,7 @@ goto set_env_variables
 :set_env_variables
 
 :: Set signtool arguments
-set SIGNTOOL_ARGS="sign /t  http://timestamp.verisign.com/scripts/timstamp.dll  /fd sha256 /sm"
+set SIGNTOOL_ARGS="sign /t  http://timestamp.digicert.com  /fd sha256 /sm"
 
 :: Change these variables to match the local build environment.
 

--- a/omaha/hammer-brave.bat
+++ b/omaha/hammer-brave.bat
@@ -35,7 +35,7 @@ goto set_env_variables
 :set_env_variables
 
 :: Set signtool arguments
-set SIGNTOOL_ARGS="sign /t  http://timestamp.digicert.com  /fd sha256 /sm"
+set SIGNTOOL_ARGS="sign /t http://timestamp.digicert.com /fd sha256 /sm"
 
 :: Change these variables to match the local build environment.
 


### PR DESCRIPTION
We already use the Digicert timestamp server in brave builds
but need to also update it here as that might not pass down.