### PR TITLE
Set specific SDK version for omaha build

### DIFF
--- a/omaha/hammer-brave.bat
+++ b/omaha/hammer-brave.bat
@@ -5,7 +5,7 @@
 set OMAHA_PSEXEC_DIR=%ProgramFiles(x86)%\pstools
 
 :: Set VS environment variables.
-call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat"
+call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x86 10.0.10586.0
 
 setlocal
 


### PR DESCRIPTION
Just calling vcvarsall.bat w/o any args, it uses latest sdk information
on current windows for setting env vars like WindowsSDKVer.
It fetches latest installed version from registry.
If we installed 10.0.18362, we can see WindowsSDKVer is `10.0.18362` by `echo` in
hammer-brave.bat.
So far, it was fine but omaha build is failed after installing 10.0.18362.
Since C77, 18362 became as required SDK version.
And omaha build will fail w/o this commit.
So, we should set required SDK version(10.0.10586) explicitly 
because it is sdk requirement for our forked omaha version.

Fix https://github.com/brave/brave-browser/issues/5387