### PR TITLE
Fix brave is always installed with en lang

### DIFF
--- a/build_omaha.py
+++ b/build_omaha.py
@@ -115,13 +115,13 @@ def Tagging(args, omaha_dir, debug):
   apply_tag_exe = os.path.join(omaha_out_dir, 'obj', 'tools', 'ApplyTag', 'ApplyTag.exe')
 
   tag_admin = os.environ.get('TAG_ADMIN', 'prefers')
-  tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&lang=en&ap=TAG_AP'
+  tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&ap=TAG_AP'
   tag = tag.replace("TAG_ADMIN", tag_admin)
   tag = tag.replace("APP_GUID", args.guid[0])
   tag = tag.replace("TAG_APP_NAME", args.tag_app_name[0])
   tag = tag.replace("TAG_AP", args.tag_ap[0])
 
-  silent_tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&lang=en&ap=TAG_AP&silent'
+  silent_tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&ap=TAG_AP&silent'
   silent_tag = silent_tag.replace("TAG_ADMIN", 'False')
   silent_tag = silent_tag.replace("APP_GUID", args.guid[0])
   silent_tag = silent_tag.replace("TAG_APP_NAME", args.tag_app_name[0])


### PR DESCRIPTION
We had lang=en in tag list. That causes our installer always uses
en localed installer and browser.

Issue: https://github.com/brave/brave-browser/issues/9712