### PR TITLE
Fix silent Brave standalone installer

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -38,7 +38,6 @@ action("build_omaha_installer") {
     "--root_out_dir=$out_dir",
     "--brave_installer_exe=$brave_installer_exe",
     "--stub_installer_exe=$brave_stub_installer_exe",
-    "--stub_silent_exe=$brave_silent_stub_installer_exe",
     "--stub_untagged_exe=$brave_untagged_stub_installer_exe",
     "--standalone_installer_exe=$brave_standalone_installer_exe",
     "--silent_installer_exe=$brave_silent_installer_exe",

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -163,7 +163,7 @@ def parse_args():
                       nargs=1)
   return parser.parse_args()
 
-def main(args):
+def main():
   args = parse_args()
   omaha_dir = os.path.join(args.root_out_dir[0], '..', '..', 'brave', 'vendor', 'omaha')
 
@@ -181,4 +181,4 @@ def main(args):
 
 
 if __name__ == '__main__':
-  sys.exit(main(sys.argv))
+  sys.exit(main())

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -112,38 +112,24 @@ def Tagging(args, omaha_dir, debug):
   silent_tag = silent_tag.replace("TAG_APP_NAME", args.tag_app_name[0])
   silent_tag = silent_tag.replace("TAG_AP", args.tag_ap[0])
 
-  source_standalone_installer = os.path.join(omaha_out_dir, 'Test_Installers', 'UNOFFICIAL_' + args.standalone_installer_exe[0])
-  target_standalone_installer_file = args.standalone_installer_exe[0]
-  if debug:
-    target_standalone_installer_file = 'Debug' + target_standalone_installer_file
-  target_standalone_installer = os.path.join(args.root_out_dir[0], target_standalone_installer_file)
-  command = [apply_tag_exe, source_standalone_installer, target_standalone_installer, tag]
-  sp.check_call(command, stderr=sp.STDOUT)
+  ApplyTag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.standalone_installer_exe[0], args.standalone_installer_exe[0], tag, args.root_out_dir[0])
+  ApplyTag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.silent_installer_exe[0], args.silent_installer_exe[0], silent_tag, args.root_out_dir[0])
+  ApplyTag(omaha_dir, debug, 'staging/BraveUpdateSetup.exe', args.stub_installer_exe[0], tag, args.root_out_dir[0])
+  ApplyTag(omaha_dir, debug, 'staging/BraveUpdateSetup.exe', args.stub_silent_exe[0], silent_tag, args.root_out_dir[0])
 
-  source_silent_installer = os.path.join(omaha_out_dir, 'Test_Installers', 'UNOFFICIAL_' + args.silent_installer_exe[0])
-  target_silent_installer_file = args.silent_installer_exe[0]
+def ApplyTag(omaha_dir, debug, source_installer, target_installer_file, tag, root_out_dir):
+  last_win_dir = 'opt-win'
   if debug:
-    target_silent_installer_file = 'Debug' + target_silent_installer_file
-  target_silent_installer = os.path.join(args.root_out_dir[0], target_silent_installer_file)
-  command = [apply_tag_exe, source_silent_installer, target_silent_installer, silent_tag]
-  sp.check_call(command, stderr=sp.STDOUT)
+    last_win_dir = 'dbg-win'
+  omaha_out_dir = os.path.join(omaha_dir, 'omaha', 'scons-out', last_win_dir)
+  apply_tag_exe = os.path.join(omaha_out_dir, 'obj', 'tools', 'ApplyTag', 'ApplyTag.exe')
 
-  source_stub_installer = os.path.join(omaha_out_dir, 'staging', 'BraveUpdateSetup.exe')
-  target_stub_installer_file = args.stub_installer_exe[0]
+  source_installer_path = os.path.join(omaha_out_dir, *source_installer.split('/'))
   if debug:
-    target_stub_installer_file = 'Debug' + target_stub_installer_file
-  target_stub_installer = os.path.join(args.root_out_dir[0], target_stub_installer_file)
-  command = [apply_tag_exe, source_stub_installer, target_stub_installer, tag]
+    target_installer_file = 'Debug' + target_installer_file
+  target_installer_path = os.path.join(root_out_dir, target_installer_file)
+  command = [apply_tag_exe, source_installer_path, target_installer_path, tag]
   sp.check_call(command, stderr=sp.STDOUT)
-
-  source_silent_stub_installer = os.path.join(omaha_out_dir, 'staging', 'BraveUpdateSetup.exe')
-  target_silent_stub_installer_file = args.stub_silent_exe[0]
-  if debug:
-    target_silent_stub_installer_file = 'Debug' + target_silent_stub_installer_file
-  target_silent_stub_installer = os.path.join(args.root_out_dir[0], target_silent_stub_installer_file)
-  command = [apply_tag_exe, source_silent_stub_installer, target_silent_stub_installer, silent_tag]
-  sp.check_call(command, stderr=sp.STDOUT)
-  return
 
 def ParseArgs():
   parser = argparse.ArgumentParser(description='build omaha installer')

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -93,12 +93,10 @@ def AddToStandaloneInstallersTxt(target_installer_text_path, file_name, app_guid
   f.close()
 
 def Tagging(args, omaha_dir, debug):
-  last_win_dir = 'opt-win'
-  if debug:
-    last_win_dir = 'dbg-win'
-  omaha_out_dir = os.path.join(omaha_dir, 'omaha', 'scons-out', last_win_dir)
-  apply_tag_exe = os.path.join(omaha_out_dir, 'obj', 'tools', 'ApplyTag', 'ApplyTag.exe')
+  TagStandalone(args, omaha_dir, debug)
+  TagSilent(args, omaha_dir, debug)
 
+def TagStandalone(args, omaha_dir, debug):
   tag_admin = os.environ.get('TAG_ADMIN', 'prefers')
   tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&ap=TAG_AP'
   tag = tag.replace("TAG_ADMIN", tag_admin)
@@ -106,15 +104,17 @@ def Tagging(args, omaha_dir, debug):
   tag = tag.replace("TAG_APP_NAME", args.tag_app_name[0])
   tag = tag.replace("TAG_AP", args.tag_ap[0])
 
+  ApplyTag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.standalone_installer_exe[0], args.standalone_installer_exe[0], tag, args.root_out_dir[0])
+  ApplyTag(omaha_dir, debug, 'staging/BraveUpdateSetup.exe', args.stub_installer_exe[0], tag, args.root_out_dir[0])
+
+def TagSilent(args, omaha_dir, debug):
   silent_tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&ap=TAG_AP&silent'
   silent_tag = silent_tag.replace("TAG_ADMIN", 'False')
   silent_tag = silent_tag.replace("APP_GUID", args.guid[0])
   silent_tag = silent_tag.replace("TAG_APP_NAME", args.tag_app_name[0])
   silent_tag = silent_tag.replace("TAG_AP", args.tag_ap[0])
 
-  ApplyTag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.standalone_installer_exe[0], args.standalone_installer_exe[0], tag, args.root_out_dir[0])
   ApplyTag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.silent_installer_exe[0], args.silent_installer_exe[0], silent_tag, args.root_out_dir[0])
-  ApplyTag(omaha_dir, debug, 'staging/BraveUpdateSetup.exe', args.stub_installer_exe[0], tag, args.root_out_dir[0])
   ApplyTag(omaha_dir, debug, 'staging/BraveUpdateSetup.exe', args.stub_silent_exe[0], silent_tag, args.root_out_dir[0])
 
 def ApplyTag(omaha_dir, debug, source_installer, target_installer_file, tag, root_out_dir):

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -51,10 +51,6 @@ def Copy_Untagged_Installers(args, omaha_dir, debug):
 
   shutil.copyfile(source_untagged_stub_installer, target_untagged_stub_installer)
 
-def PrepareUntaggedInstallers(args, omaha_dir):
-  PrepareUntaggedStandalone(args, omaha_dir)
-  PrepareUntaggedSilent(args, omaha_dir)
-
 def PrepareUntaggedStandalone(args, omaha_dir):
   PrepareUntagged(omaha_dir, args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0], args.install_switch[0], args.brave_full_version[0],
     [(args.standalone_installer_exe[0], args.brave_installer_exe[0]),
@@ -104,10 +100,6 @@ def AddToStandaloneInstallersTxt(target_installer_text_path, file_name, app_guid
   f = open(target_installer_text_path,'a+')
   f.write(installer_text + '\n')
   f.close()
-
-def Tagging(args, omaha_dir, debug):
-  TagStandalone(args, omaha_dir, debug)
-  TagSilent(args, omaha_dir, debug)
 
 def TagStandalone(args, omaha_dir, debug):
   tag_admin = os.environ.get('TAG_ADMIN', 'prefers')

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -73,32 +73,23 @@ def PrepareStandalone(args, omaha_dir):
   f.write(newdata)
   f.close()
 
-  # update standalone_installers.txt.
-  installer_text = "('STANDALONE_FILE_NAME', 'STANDALONE_FILE_NAME', [('BRAVE_VERSION', '$MAIN_DIR/standalone/BRAVE_INSTALLER_EXE', 'APP_GUID')], None, None, None, False, '', '')"
-  installer_text = installer_text.replace("APP_GUID", args.guid[0])
-  installer_text = installer_text.replace("STANDALONE_FILE_NAME", os.path.splitext(args.standalone_installer_exe[0])[0])
-  installer_text = installer_text.replace("BRAVE_INSTALLER_EXE", args.brave_installer_exe[0])
-  installer_text = installer_text.replace("BRAVE_VERSION", args.brave_full_version[0])
-
-  # add untagged installer info to standalone_installers.txt.
-  untagged_installer_text = "('UNTAGGED_FILE_NAME', 'UNTAGGED_FILE_NAME', [('BRAVE_VERSION', '$MAIN_DIR/standalone/UNTAGGED_INSTALLER_EXE', 'APP_GUID')], None, None, None, False, '', '')"
-  untagged_installer_text = untagged_installer_text.replace("APP_GUID", args.guid[0])
-  untagged_installer_text = untagged_installer_text.replace("UNTAGGED_FILE_NAME", os.path.splitext(args.untagged_installer_exe[0])[0])
-  untagged_installer_text = untagged_installer_text.replace("UNTAGGED_INSTALLER_EXE", args.untagged_installer_exe[0])
-  untagged_installer_text = untagged_installer_text.replace("BRAVE_VERSION", args.brave_full_version[0])
-
-  # add silent installer info to standalone_installers.txt.
-  silent_installer_text = "('SILENT_FILE_NAME', 'SILENT_FILE_NAME', [('BRAVE_VERSION', '$MAIN_DIR/standalone/SILENT_INSTALLER_EXE', 'APP_GUID')], None, None, None, False, '', '')"
-  silent_installer_text = silent_installer_text.replace("APP_GUID", args.guid[0])
-  silent_installer_text = silent_installer_text.replace("SILENT_FILE_NAME", os.path.splitext(args.silent_installer_exe[0])[0])
-  silent_installer_text = silent_installer_text.replace("SILENT_INSTALLER_EXE", args.silent_installer_exe[0])
-  silent_installer_text = silent_installer_text.replace("BRAVE_VERSION", args.brave_full_version[0])
-
   target_installer_text_path = os.path.join(omaha_dir, 'omaha', 'standalone', 'standalone_installers.txt')
-  f = open(target_installer_text_path,'w')
+
+  # Clear the file:
+  open(target_installer_text_path,'w').close()
+
+  AddToStandaloneInstallersTxt(target_installer_text_path, args.standalone_installer_exe[0], args.guid[0], args.brave_installer_exe[0], args.brave_full_version[0])
+  AddToStandaloneInstallersTxt(target_installer_text_path, args.untagged_installer_exe[0], args.guid[0], args.untagged_installer_exe[0], args.brave_full_version[0])
+  AddToStandaloneInstallersTxt(target_installer_text_path, args.silent_installer_exe[0], args.guid[0], args.silent_installer_exe[0], args.brave_full_version[0])
+
+def AddToStandaloneInstallersTxt(target_installer_text_path, file_name, app_guid, brave_installer_exe, brave_version):
+  installer_text = "('FILE_NAME', 'FILE_NAME', [('BRAVE_VERSION', '$MAIN_DIR/standalone/BRAVE_INSTALLER_EXE', 'APP_GUID')], None, None, None, False, '', '')"
+  installer_text = installer_text.replace("FILE_NAME", os.path.splitext(file_name)[0])
+  installer_text = installer_text.replace("APP_GUID", app_guid)
+  installer_text = installer_text.replace("BRAVE_INSTALLER_EXE", brave_installer_exe)
+  installer_text = installer_text.replace("BRAVE_VERSION", brave_version)
+  f = open(target_installer_text_path,'a+')
   f.write(installer_text + '\n')
-  f.write(untagged_installer_text + '\n')
-  f.write(silent_installer_text)
   f.close()
 
 def Tagging(args, omaha_dir, debug):

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -10,7 +10,7 @@ import subprocess as sp
 import sys
 
 
-def Build(omaha_dir, build_all):
+def build(omaha_dir, build_all):
   # move to omaha/omaha and start build.
   os.chdir(os.path.join(omaha_dir, 'omaha'))
 
@@ -29,7 +29,7 @@ def Build(omaha_dir, build_all):
 
   sp.check_call(command, stderr=sp.STDOUT)
 
-def Copy_Untagged_Installers(args, omaha_dir, debug):
+def copy_untagged_installers(args, omaha_dir, debug):
   last_win_dir = 'opt-win'
   if debug:
     last_win_dir = 'dbg-win'
@@ -51,19 +51,19 @@ def Copy_Untagged_Installers(args, omaha_dir, debug):
 
   shutil.copyfile(source_untagged_stub_installer, target_untagged_stub_installer)
 
-def PrepareUntaggedStandalone(args, omaha_dir):
-  PrepareUntagged(omaha_dir, args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0], args.install_switch[0], args.brave_full_version[0],
+def prepare_untagged_standalone(args, omaha_dir):
+  prepare_untagged(omaha_dir, args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0], args.install_switch[0], args.brave_full_version[0],
     [(args.standalone_installer_exe[0], args.brave_installer_exe[0]),
      (args.untagged_installer_exe[0], args.untagged_installer_exe[0])]
   )
 
-def PrepareUntaggedSilent(args, omaha_dir):
-  PrepareUntagged(
+def prepare_untagged_silent(args, omaha_dir):
+  prepare_untagged(
     omaha_dir, args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0], '--do-not-launch-chrome ' + args.install_switch[0], args.brave_full_version[0],
     [(args.silent_installer_exe[0], args.silent_installer_exe[0])]
   )
 
-def PrepareUntagged(omaha_dir, root_out_dir, brave_installer_exe, app_guid, install_switch, brave_full_version, details):
+def prepare_untagged(omaha_dir, root_out_dir, brave_installer_exe, app_guid, install_switch, brave_full_version, details):
   # copy brave installer to create standalone installer.
   installer_file = os.path.join(root_out_dir, brave_installer_exe)
 
@@ -88,10 +88,10 @@ def PrepareUntagged(omaha_dir, root_out_dir, brave_installer_exe, app_guid, inst
   open(target_installer_text_path,'w').close()
 
   for file_name, installer_exe in details:
-    AddToStandaloneInstallersTxt(target_installer_text_path, file_name, app_guid, installer_exe, brave_full_version)
+    add_to_standalone_installers_txt(target_installer_text_path, file_name, app_guid, installer_exe, brave_full_version)
     shutil.copyfile(installer_file, os.path.join(omaha_dir, 'omaha', 'standalone', installer_exe))
 
-def AddToStandaloneInstallersTxt(target_installer_text_path, file_name, app_guid, brave_installer_exe, brave_version):
+def add_to_standalone_installers_txt(target_installer_text_path, file_name, app_guid, brave_installer_exe, brave_version):
   installer_text = "('FILE_NAME', 'FILE_NAME', [('BRAVE_VERSION', '$MAIN_DIR/standalone/BRAVE_INSTALLER_EXE', 'APP_GUID')], None, None, None, False, '', '')"
   installer_text = installer_text.replace("FILE_NAME", os.path.splitext(file_name)[0])
   installer_text = installer_text.replace("APP_GUID", app_guid)
@@ -101,7 +101,7 @@ def AddToStandaloneInstallersTxt(target_installer_text_path, file_name, app_guid
   f.write(installer_text + '\n')
   f.close()
 
-def TagStandalone(args, omaha_dir, debug):
+def tag_standalone(args, omaha_dir, debug):
   tag_admin = os.environ.get('TAG_ADMIN', 'prefers')
   tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&ap=TAG_AP'
   tag = tag.replace("TAG_ADMIN", tag_admin)
@@ -109,19 +109,19 @@ def TagStandalone(args, omaha_dir, debug):
   tag = tag.replace("TAG_APP_NAME", args.tag_app_name[0])
   tag = tag.replace("TAG_AP", args.tag_ap[0])
 
-  ApplyTag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.standalone_installer_exe[0], args.standalone_installer_exe[0], tag, args.root_out_dir[0])
-  ApplyTag(omaha_dir, debug, 'staging/BraveUpdateSetup.exe', args.stub_installer_exe[0], tag, args.root_out_dir[0])
+  apply_tag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.standalone_installer_exe[0], args.standalone_installer_exe[0], tag, args.root_out_dir[0])
+  apply_tag(omaha_dir, debug, 'staging/BraveUpdateSetup.exe', args.stub_installer_exe[0], tag, args.root_out_dir[0])
 
-def TagSilent(args, omaha_dir, debug):
+def tag_silent(args, omaha_dir, debug):
   silent_tag = 'appguid=APP_GUID&appname=TAG_APP_NAME&needsadmin=TAG_ADMIN&ap=TAG_AP&silent'
   silent_tag = silent_tag.replace("TAG_ADMIN", 'False')
   silent_tag = silent_tag.replace("APP_GUID", args.guid[0])
   silent_tag = silent_tag.replace("TAG_APP_NAME", args.tag_app_name[0])
   silent_tag = silent_tag.replace("TAG_AP", args.tag_ap[0])
 
-  ApplyTag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.silent_installer_exe[0], args.silent_installer_exe[0], silent_tag, args.root_out_dir[0])
+  apply_tag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.silent_installer_exe[0], args.silent_installer_exe[0], silent_tag, args.root_out_dir[0])
 
-def ApplyTag(omaha_dir, debug, source_installer, target_installer_file, tag, root_out_dir):
+def apply_tag(omaha_dir, debug, source_installer, target_installer_file, tag, root_out_dir):
   last_win_dir = 'opt-win'
   if debug:
     last_win_dir = 'dbg-win'
@@ -135,7 +135,7 @@ def ApplyTag(omaha_dir, debug, source_installer, target_installer_file, tag, roo
   command = [apply_tag_exe, source_installer_path, target_installer_path, tag]
   sp.check_call(command, stderr=sp.STDOUT)
 
-def ParseArgs():
+def parse_args():
   parser = argparse.ArgumentParser(description='build omaha installer')
   parser.add_argument('--root_out_dir',
                       nargs=1)
@@ -163,22 +163,22 @@ def ParseArgs():
                       nargs=1)
   return parser.parse_args()
 
-def Main(args):
-  args = ParseArgs()
+def main(args):
+  args = parse_args()
   omaha_dir = os.path.join(args.root_out_dir[0], '..', '..', 'brave', 'vendor', 'omaha')
 
-  PrepareUntaggedStandalone(args, omaha_dir)
-  Build(omaha_dir, False)
-  TagStandalone(args, omaha_dir, False)
+  prepare_untagged_standalone(args, omaha_dir)
+  build(omaha_dir, False)
+  tag_standalone(args, omaha_dir, False)
 
-  PrepareUntaggedSilent(args, omaha_dir)
-  Build(omaha_dir, False)
-  TagSilent(args, omaha_dir, False)
+  prepare_untagged_silent(args, omaha_dir)
+  build(omaha_dir, False)
+  tag_silent(args, omaha_dir, False)
 
-  Copy_Untagged_Installers(args, omaha_dir, False)
+  copy_untagged_installers(args, omaha_dir, False)
 
   return 0
 
 
 if __name__ == '__main__':
-  sys.exit(Main(sys.argv))
+  sys.exit(main(sys.argv))

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -10,7 +10,7 @@ import subprocess as sp
 import sys
 
 
-def Build(args, omaha_dir, build_all):
+def Build(omaha_dir, build_all):
   # move to omaha/omaha and start build.
   os.chdir(os.path.join(omaha_dir, 'omaha'))
 
@@ -189,7 +189,7 @@ def Main(args):
   omaha_dir = os.path.join(args.root_out_dir[0], '..', '..', 'brave', 'vendor', 'omaha')
 
   PrepareStandalone(args, omaha_dir)
-  Build(args, omaha_dir, False)
+  Build(omaha_dir, False)
   Tagging(args, omaha_dir, False)
   Copy_Untagged_Installers(args, omaha_dir, False)
 

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -120,7 +120,6 @@ def TagSilent(args, omaha_dir, debug):
   silent_tag = silent_tag.replace("TAG_AP", args.tag_ap[0])
 
   ApplyTag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.silent_installer_exe[0], args.silent_installer_exe[0], silent_tag, args.root_out_dir[0])
-  ApplyTag(omaha_dir, debug, 'staging/BraveUpdateSetup.exe', args.stub_silent_exe[0], silent_tag, args.root_out_dir[0])
 
 def ApplyTag(omaha_dir, debug, source_installer, target_installer_file, tag, root_out_dir):
   last_win_dir = 'opt-win'
@@ -145,8 +144,6 @@ def ParseArgs():
   parser.add_argument('--stub_installer_exe',
                       nargs=1)
   parser.add_argument('--stub_untagged_exe',
-                      nargs=1)
-  parser.add_argument('--stub_silent_exe',
                       nargs=1)
   parser.add_argument('--standalone_installer_exe',
                       nargs=1)


### PR DESCRIPTION
This PR is the main implementation of the fix for https://github.com/brave/brave-browser/issues/6240. There, it is described how the silent standalone installer is not truly silent because it opens a browser window.

To fix this, we need to make Omaha pass the additional flag `--do-not-launch-chrome` when it silently installs Brave. This required quite a bit of refactoring of `build_omaha.py`, as shown in this PR. It also introduces a second round of building Omaha. The reason for this is that the flag `--do-not-launch-chrome` is hard-coded in a file `{Brave's GUID}.gup`. But we don't want the flag to be there always; Just for the silent installer. So we generate the version of the file without the flag, then instruct Omaha to build. Then we generate the file with the flag, and build again.