### PR TITLE
Update GitHub links.

### DIFF
--- a/doc/DeveloperSetupGuide.md
+++ b/doc/DeveloperSetupGuide.md
@@ -40,8 +40,8 @@ The following packages are required to build Omaha:
   * The GO programming language
     * Download [here](https://golang.org/dl/) 
     * Change this line in hammer.bat if you installed to a different location: `set GOROOT=C:\go`.
-  * Google Protocol Buffers (3.9.2 or higher) [here](https://github.com/google/protobuf/releases).
-    * From the [release page](https://github.com/google/protobuf/releases), download the zip file `protoc-$VERSION-win32.zip`. It contains the protoc binary. Unzip the contents under `C:\protobuf`. After that, download the zip file `protobuf-cpp-$VERSION.zip`. Unzip the `src` sub-directory contents to `C:\protobuf\src`. If other directory is used, please edit the environment variables in the hammer.bat, specifically, `OMAHA_PROTOBUF_BIN_DIR` and `OMAHA_PROTOBUF_SRC_DIR`.
+  * Google Protocol Buffers (3.9.2 or higher) [here](https://github.com/protocolbuffers/protobuf/releases).
+    * From the [release page](https://github.com/protocolbuffers/protobuf/releases), download the zip file `protoc-$VERSION-win32.zip`. It contains the protoc binary. Unzip the contents under `C:\protobuf`. After that, download the zip file `protobuf-cpp-$VERSION.zip`. Unzip the `src` sub-directory contents to `C:\protobuf\src`. If other directory is used, please edit the environment variables in the hammer.bat, specifically, `OMAHA_PROTOBUF_BIN_DIR` and `OMAHA_PROTOBUF_SRC_DIR`.
   * Third-party dependencies:
     * breakpad. Download [here](https://codeload.github.com/google/breakpad/zip/master). 
       - Unzip everything inside `breakpad-master.zip\breakpad-master` to `third_party\breakpad`.

--- a/doc/OmahaOverview.html
+++ b/doc/OmahaOverview.html
@@ -1143,7 +1143,7 @@ It is important the same binary works the same way on different operating system
 </h3>
 <p>
 <blockquote>The Google Update server is not part of the Omaha open source project. Providing updates for applications requires a server that implements the
-<a href=http://github.com/google/omaha/blob/master/doc/ServerProtocolV3.md target=_self>Omaha Server Protocol</a>.</blockquote>
+<a href=https://github.com/google/omaha/blob/master/doc/ServerProtocolV3.md target=_self>Omaha Server Protocol</a>.</blockquote>
 </p>
 <p>
   Omaha has two server components: autoupdate and download. This separation of server responsibilities is desirable because the requirements are different: downloading large binaries takes high bandwidth and can tolerate relatively high latency, whereas small transactions such as update pings may be much more frequent but require extremely low bandwidth per transaction. These differences allow Google to provision the two servers appropriately.

--- a/omaha/hammer-brave.bat
+++ b/omaha/hammer-brave.bat
@@ -60,13 +60,13 @@ set OMAHA_NET_DIR=%WINDIR%\Microsoft.NET\Framework\v2.0.50727
 set OMAHA_NETFX_TOOLS_DIR=%WindowsSDK_ExecutablePath_x86%
 
 :: This directory is needed to find protoc.exe, which is the protocol buffer
-:: compiler. From the release page https://github.com/google/protobuf/releases,
+:: compiler. From the release page https://github.com/protocolbuffers/protobuf/releases,
 :: download the zip file protoc-$VERSION-win32.zip. It contains the protoc
 :: binary. Unzip the contents under C:\protobuf.
 set OMAHA_PROTOBUF_BIN_DIR=C:\protobuf\bin
 
 :: This directory is needed to find the protocol buffer source files. From the
-:: release page https://github.com/google/protobuf/releases, download the zip
+:: release page https://github.com/protocolbuffers/protobuf/releases, download the zip
 :: file protobuf-cpp-$VERSION.zip. Unzip the "src" sub-directory contents to
 :: C:\protobuf\src.
 set OMAHA_PROTOBUF_SRC_DIR=C:\protobuf\src

--- a/omaha/hammer.bat
+++ b/omaha/hammer.bat
@@ -55,13 +55,13 @@ set SIGNTOOL_ARGS="sign /t http://timestamp.digicert.com /fd sha256 /sm"
 set GOROOT=C:\go
 
 :: This directory is needed to find protoc.exe, which is the protocol buffer
-:: compiler. From the release page https://github.com/google/protobuf/releases,
+:: compiler. From the release page https://github.com/protocolbuffers/protobuf/releases,
 :: download the zip file protoc-$VERSION-win32.zip. It contains the protoc
 :: binary. Unzip the contents under C:\protobuf.
 set OMAHA_PROTOBUF_BIN_DIR=C:\protobuf-2020-sep-rebase\bin
 
 :: This directory is needed to find the protocol buffer source files. From the
-:: release page https://github.com/google/protobuf/releases, download the zip
+:: release page https://github.com/protocolbuffers/protobuf/releases, download the zip
 :: file protobuf-cpp-$VERSION.zip. Unzip the "src" sub-directory contents to
 :: C:\protobuf\src.
 set OMAHA_PROTOBUF_SRC_DIR=C:\protobuf-2020-sep-rebase\src

--- a/third_party/breakpad/DEPS
+++ b/third_party/breakpad/DEPS
@@ -40,7 +40,7 @@ deps = {
 
   # Protobuf.
   "src/src/third_party/protobuf/protobuf":
-    "https://github.com/google/protobuf.git" +
+    "https://github.com/protocolbuffers/protobuf.git" +
       "@cb6dd4ef5f82e41e06179dcd57d3b1d9246ad6ac",
 
   # GYP project generator.

--- a/third_party/breakpad/src/processor/proto/README
+++ b/third_party/breakpad/src/processor/proto/README
@@ -1,5 +1,5 @@
 If you wish to use these protobufs, you must generate their source files
-using  protoc from the protobuf project (https://github.com/google/protobuf).
+using  protoc from the protobuf project (https://github.com/protocolbuffers/protobuf).
 
 -----
 Troubleshooting for Protobuf:

--- a/third_party/googletest/README.md
+++ b/third_party/googletest/README.md
@@ -70,7 +70,7 @@ following notable projects:
 *   The [Chromium projects](http://www.chromium.org/) (behind the Chrome browser
     and Chrome OS).
 *   The [LLVM](http://llvm.org/) compiler.
-*   [Protocol Buffers](https://github.com/google/protobuf), Google's data
+*   [Protocol Buffers](https://github.com/protocolbuffers/protobuf), Google's data
     interchange format.
 *   The [OpenCV](http://opencv.org/) computer vision library.
 

--- a/third_party/googletest/googlemock/README.md
+++ b/third_party/googletest/googlemock/README.md
@@ -40,5 +40,5 @@ project](http://code.google.com/p/cppclean/) and under the Apache
 License, which is different from Google Mock's license.
 
 Google Mock is a part of
-[Google Test C++ testing framework](http://github.com/google/googletest/) and a
+[Google Test C++ testing framework](https://github.com/google/googletest/) and a
 subject to the same requirements.


### PR DESCRIPTION
The protobuf repo has moved to a different GitHub org.