### PR TITLE
Avoid local changes after build

### DIFF
--- a/build_omaha.py
+++ b/build_omaha.py
@@ -180,11 +180,11 @@ def main():
   args = parse_args()
   omaha_dir = os.path.join(args.root_out_dir[0], '..', '..', 'brave', 'vendor', 'omaha')
 
-  installer_metadata_dir = prepare_untagged_standalone(args, omaha_dir)
+  installer_metadata_dir = prepare_untagged_standalone(args, omaha_dir, False)
   build(omaha_dir, installer_metadata_dir, False)
   tag_standalone(args, omaha_dir, False)
 
-  installer_metadata_dir = prepare_untagged_silent(args, omaha_dir)
+  installer_metadata_dir = prepare_untagged_silent(args, omaha_dir, False)
   build(omaha_dir, installer_metadata_dir, False)
   tag_silent(args, omaha_dir, False)
 

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -64,7 +64,7 @@ def prepare_untagged_standalone(args, omaha_dir, debug):
   )
 
 def prepare_untagged_silent(args, omaha_dir, debug):
-  prepare_untagged(
+  return prepare_untagged(
     omaha_dir, 'silent', args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0],
     '--do-not-launch-chrome ' + args.install_switch[0], args.brave_full_version[0],
     [(args.silent_installer_exe[0], args.silent_installer_exe[0])], debug

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -103,15 +103,18 @@ def prepare_untagged(omaha_dir, name, root_out_dir, brave_installer_exe, app_gui
   open(target_installer_text_path, 'w').close()
 
   for file_name, installer_exe in details:
-    add_to_standalone_installers_txt(target_installer_text_path, file_name, app_guid, installer_exe, brave_full_version)
+    brave_installer_path = os.path.join(root_out_dir, brave_installer_exe)
+    brave_installer_path_fixed_name = os.path.join(out_dir, installer_exe)
+    shutil.copyfile(brave_installer_path, brave_installer_path_fixed_name)
+    add_to_standalone_installers_txt(target_installer_text_path, file_name, app_guid, brave_installer_path_fixed_name, brave_full_version)
 
   return out_dir
 
-def add_to_standalone_installers_txt(target_installer_text_path, file_name, app_guid, brave_installer_exe, brave_version):
+def add_to_standalone_installers_txt(target_installer_text_path, file_name, app_guid, installer_exe_path, brave_version):
   installer_text = "('FILE_NAME', 'FILE_NAME', [('BRAVE_VERSION', 'BRAVE_INSTALLER_EXE', 'APP_GUID')], None, None, None, False, '', '')"
   installer_text = installer_text.replace("FILE_NAME", os.path.splitext(file_name)[0])
   installer_text = installer_text.replace("APP_GUID", app_guid)
-  installer_text = installer_text.replace("BRAVE_INSTALLER_EXE", brave_installer_exe.replace('\\', '/'))
+  installer_text = installer_text.replace("BRAVE_INSTALLER_EXE", installer_exe_path.replace('\\', '/'))
   installer_text = installer_text.replace("BRAVE_VERSION", brave_version)
   f = open(target_installer_text_path,'a+')
   f.write(installer_text + '\n')

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -10,7 +10,7 @@ import subprocess as sp
 import sys
 
 
-def build(omaha_dir, build_all):
+def build(omaha_dir, standalone_installers_dir, build_all):
   # move to omaha/omaha and start build.
   os.chdir(os.path.join(omaha_dir, 'omaha'))
 
@@ -22,7 +22,8 @@ def build(omaha_dir, build_all):
   mode = 'opt-win'
   if build_all:
     mode = 'all'
-  command = ['hammer.bat', 'MODE=' + mode, '--all', '--sha2_authenticode_file=' + key_pfx_path,
+  command = ['hammer.bat', 'MODE=' + mode, '--all', '--standalone_installers_dir=' + standalone_installers_dir,
+    '--sha2_authenticode_file=' + key_pfx_path,
     '--sha2_authenticode_password=' + authenticode_password, '--sha1_authenticode_file=' + key_pfx_path,
     '--sha1_authenticode_password=' + authenticode_password, '--authenticode_file=' + key_pfx_path,
     '--authenticode_password=' + authenticode_password]
@@ -54,23 +55,29 @@ def get_omaha_out_dir(omaha_dir, debug):
     last_win_dir = 'dbg-win'
   return os.path.join(omaha_dir, 'omaha', 'scons-out', last_win_dir)
 
-def prepare_untagged_standalone(args, omaha_dir):
-  prepare_untagged(omaha_dir, args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0], args.install_switch[0], args.brave_full_version[0],
+def prepare_untagged_standalone(args, omaha_dir, debug):
+  return prepare_untagged(
+    omaha_dir, 'standalone', args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0],
+    args.install_switch[0], args.brave_full_version[0],
     [(args.standalone_installer_exe[0], args.brave_installer_exe[0]),
-     (args.untagged_installer_exe[0], args.untagged_installer_exe[0])]
+     (args.untagged_installer_exe[0], args.untagged_installer_exe[0])], debug
   )
 
-def prepare_untagged_silent(args, omaha_dir):
+def prepare_untagged_silent(args, omaha_dir, debug):
   prepare_untagged(
-    omaha_dir, args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0], '--do-not-launch-chrome ' + args.install_switch[0], args.brave_full_version[0],
-    [(args.silent_installer_exe[0], args.silent_installer_exe[0])]
+    omaha_dir, 'silent', args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0],
+    '--do-not-launch-chrome ' + args.install_switch[0], args.brave_full_version[0],
+    [(args.silent_installer_exe[0], args.silent_installer_exe[0])], debug
   )
 
-def prepare_untagged(omaha_dir, root_out_dir, brave_installer_exe, app_guid, install_switch, brave_full_version, details):
-  # copy brave installer to create standalone installer.
-  installer_file = os.path.join(root_out_dir, brave_installer_exe)
+def prepare_untagged(omaha_dir, name, root_out_dir, brave_installer_exe, app_guid, install_switch, brave_full_version, details, debug):
+  omaha_out_dir = get_omaha_out_dir(omaha_dir, debug)
+  out_dir = os.path.join(omaha_out_dir, 'Brave_Installers', name)
 
-  # prepare manifset file.
+  if not os.path.exists(out_dir):
+    os.makedirs(out_dir)
+
+  # prepare manifest file.
   f = open(os.path.join(omaha_dir, 'manifest_template.gup'),'r')
   filedata = f.read()
   f.close()
@@ -79,26 +86,32 @@ def prepare_untagged(omaha_dir, root_out_dir, brave_installer_exe, app_guid, ins
   newdata = newdata.replace("BRAVE_INSTALLER_EXE", brave_installer_exe)
   newdata = newdata.replace("INSTALL_SWITCH", install_switch)
 
+  target_manifest_dir = os.path.join(out_dir, 'manifests')
+
+  if not os.path.exists(target_manifest_dir):
+    os.mkdir(target_manifest_dir)
+
   target_manifest_file = app_guid + '.gup'
-  target_manifest_path = os.path.join(omaha_dir, 'omaha', 'standalone', 'manifests', target_manifest_file)
-  f = open(target_manifest_path,'w')
+  target_manifest_path = os.path.join(target_manifest_dir, target_manifest_file)
+  f = open(target_manifest_path, 'w')
   f.write(newdata)
   f.close()
 
-  target_installer_text_path = os.path.join(omaha_dir, 'omaha', 'standalone', 'standalone_installers.txt')
+  target_installer_text_path = os.path.join(out_dir, 'standalone_installers.txt')
 
   # Clear the file:
-  open(target_installer_text_path,'w').close()
+  open(target_installer_text_path, 'w').close()
 
   for file_name, installer_exe in details:
     add_to_standalone_installers_txt(target_installer_text_path, file_name, app_guid, installer_exe, brave_full_version)
-    shutil.copyfile(installer_file, os.path.join(omaha_dir, 'omaha', 'standalone', installer_exe))
+
+  return out_dir
 
 def add_to_standalone_installers_txt(target_installer_text_path, file_name, app_guid, brave_installer_exe, brave_version):
-  installer_text = "('FILE_NAME', 'FILE_NAME', [('BRAVE_VERSION', '$MAIN_DIR/standalone/BRAVE_INSTALLER_EXE', 'APP_GUID')], None, None, None, False, '', '')"
+  installer_text = "('FILE_NAME', 'FILE_NAME', [('BRAVE_VERSION', 'BRAVE_INSTALLER_EXE', 'APP_GUID')], None, None, None, False, '', '')"
   installer_text = installer_text.replace("FILE_NAME", os.path.splitext(file_name)[0])
   installer_text = installer_text.replace("APP_GUID", app_guid)
-  installer_text = installer_text.replace("BRAVE_INSTALLER_EXE", brave_installer_exe)
+  installer_text = installer_text.replace("BRAVE_INSTALLER_EXE", brave_installer_exe.replace('\\', '/'))
   installer_text = installer_text.replace("BRAVE_VERSION", brave_version)
   f = open(target_installer_text_path,'a+')
   f.write(installer_text + '\n')
@@ -167,12 +180,12 @@ def main():
   args = parse_args()
   omaha_dir = os.path.join(args.root_out_dir[0], '..', '..', 'brave', 'vendor', 'omaha')
 
-  prepare_untagged_standalone(args, omaha_dir)
-  build(omaha_dir, False)
+  installer_metadata_dir = prepare_untagged_standalone(args, omaha_dir)
+  build(omaha_dir, installer_metadata_dir, False)
   tag_standalone(args, omaha_dir, False)
 
-  prepare_untagged_silent(args, omaha_dir)
-  build(omaha_dir, False)
+  installer_metadata_dir = prepare_untagged_silent(args, omaha_dir)
+  build(omaha_dir, installer_metadata_dir, False)
   tag_silent(args, omaha_dir, False)
 
   copy_untagged_installers(args, omaha_dir, False)

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -30,10 +30,7 @@ def build(omaha_dir, build_all):
   sp.check_call(command, stderr=sp.STDOUT)
 
 def copy_untagged_installers(args, omaha_dir, debug):
-  last_win_dir = 'opt-win'
-  if debug:
-    last_win_dir = 'dbg-win'
-  omaha_out_dir = os.path.join(omaha_dir, 'omaha', 'scons-out', last_win_dir)
+  omaha_out_dir = get_omaha_out_dir(omaha_dir, debug)
 
   source_untagged_installer = os.path.join(omaha_out_dir, 'Test_Installers', 'UNOFFICIAL_' + args.untagged_installer_exe[0])
   target_untagged_installer_file = args.untagged_installer_exe[0]
@@ -50,6 +47,12 @@ def copy_untagged_installers(args, omaha_dir, debug):
   target_untagged_stub_installer = os.path.join(args.root_out_dir[0], target_untagged_stub_installer_file)
 
   shutil.copyfile(source_untagged_stub_installer, target_untagged_stub_installer)
+
+def get_omaha_out_dir(omaha_dir, debug):
+  last_win_dir = 'opt-win'
+  if debug:
+    last_win_dir = 'dbg-win'
+  return os.path.join(omaha_dir, 'omaha', 'scons-out', last_win_dir)
 
 def prepare_untagged_standalone(args, omaha_dir):
   prepare_untagged(omaha_dir, args.root_out_dir[0], args.brave_installer_exe[0], args.guid[0], args.install_switch[0], args.brave_full_version[0],
@@ -122,10 +125,7 @@ def tag_silent(args, omaha_dir, debug):
   apply_tag(omaha_dir, debug, 'Test_Installers/UNOFFICIAL_' + args.silent_installer_exe[0], args.silent_installer_exe[0], silent_tag, args.root_out_dir[0])
 
 def apply_tag(omaha_dir, debug, source_installer, target_installer_file, tag, root_out_dir):
-  last_win_dir = 'opt-win'
-  if debug:
-    last_win_dir = 'dbg-win'
-  omaha_out_dir = os.path.join(omaha_dir, 'omaha', 'scons-out', last_win_dir)
+  omaha_out_dir = get_omaha_out_dir(omaha_dir, debug)
   apply_tag_exe = os.path.join(omaha_out_dir, 'obj', 'tools', 'ApplyTag', 'ApplyTag.exe')
 
   source_installer_path = os.path.join(omaha_out_dir, *source_installer.split('/'))

--- a/omaha/hammer.bat
+++ b/omaha/hammer.bat
@@ -5,7 +5,7 @@
 set OMAHA_PSEXEC_DIR=%ProgramFiles(x86)%\pstools
 
 :: Set VS environment variables.
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64_x86 10.0.18362.0
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64_x86 10.0.18362.0
 
 setlocal
 

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -268,6 +268,14 @@ AddOption(
     default=''
 )
 
+AddOption(
+    '--standalone_installers_dir',
+    action='store',
+    nargs=1,
+    type='string',
+    default='$MAIN_DIR/standalone'
+)
+
 # Declare various boolean states.
 DeclareBit('is_google_update_build', 'True if building Google Update')
 DeclareBit('official_installers', 'Building using checked-in binaries')
@@ -398,6 +406,8 @@ print 'Building versions: %s' % ', '.join(
 build_number = GetOption('build_number')
 if build_number:
   print 'Build number: %s' % build_number
+
+win_env['standalone_installers_dir'] = GetOption('standalone_installers_dir')
 
 win_env['omaha_versions_info'] = omaha_versions_info
 

--- a/omaha/standalone/build.scons
+++ b/omaha/standalone/build.scons
@@ -26,11 +26,13 @@ for omaha_version_info in env['omaha_versions_info']:
 
   source_binary = '$OBJ_ROOT/mi_exe_stub/%smi_exe_stub.exe' % (prefix)
 
+  standalone_installers_dir = env['standalone_installers_dir']
+
   standalone_installer.BuildOfflineInstallersVersion(
       env,
       omaha_version_info,
       '$STAGING_DIR',
       source_binary,
-      '$MAIN_DIR/standalone/standalone_installers.txt',
-      '$MAIN_DIR/standalone/manifests',
+      standalone_installers_dir + '/standalone_installers.txt',
+      standalone_installers_dir + '/manifests',
       prefix)


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/21103.

Previously, build_omaha.py and thus BUILD.gn modified omaha/standalone/standalone_installers.txt. This made `npm run sync` in brave-browser fail with error "You have unstaged changes". This PR fixes this.