### PR TITLE
Don't require KEY_PFX_PATH & AUTHENTICODE_PASSWORD

### DIFF
--- a/build_omaha.py
+++ b/build_omaha.py
@@ -22,11 +22,15 @@ def build(omaha_dir, standalone_installers_dir, build_all):
   mode = 'opt-win'
   if build_all:
     mode = 'all'
-  command = ['hammer.bat', 'MODE=' + mode, '--all', '--standalone_installers_dir=' + standalone_installers_dir,
-    '--sha2_authenticode_file=' + key_pfx_path,
-    '--sha2_authenticode_password=' + authenticode_password, '--sha1_authenticode_file=' + key_pfx_path,
-    '--sha1_authenticode_password=' + authenticode_password, '--authenticode_file=' + key_pfx_path,
-    '--authenticode_password=' + authenticode_password]
+  command = ['hammer.bat', 'MODE=' + mode, '--all', '--standalone_installers_dir=' + standalone_installers_dir]
+  if key_pfx_path:
+    command.append('--authenticode_file=' + key_pfx_path)
+    command.append('--sha1_authenticode_file=' + key_pfx_path)
+    command.append('--sha2_authenticode_file=' + key_pfx_path)
+  if authenticode_password:
+    command.append('--authenticode_password=' + authenticode_password)
+    command.append('--sha1_authenticode_password=' + authenticode_password)
+    command.append('--sha2_authenticode_password=' + authenticode_password)
 
   sp.check_call(command, stderr=sp.STDOUT)
 


### PR DESCRIPTION
Previously, build_omaha.py failed with the error below when those environment variables were not set:

```
Could not parse input as either PE32 or MSI:
PE32: authenticodetag: error parsing headers: file does not have certificate data
MSI: msi file is not an msi file: either the header signature is missing or the clsid is not zero as required
exit status 1
scons: *** [scons-out\opt-win\obj\installers\BraveUpdateSetup.exe] Error 1
scons: building terminated because of errors.
```

Resolves #42.