### PR TITLE
Bump version to 1.361.113

### DIFF
--- a/omaha/VERSION
+++ b/omaha/VERSION
@@ -5,4 +5,4 @@
 version_major = 1    # 1-65535
 version_minor = 3    # 0-65535
 version_build = 361  # 1-65535
-version_patch = 111    # 0-65535
+version_patch = 113    # 0-65535


### PR DESCRIPTION
This is necessary if we want to release #45 (and potentially other changes) to users.