### PR TITLE
Do not use parallel builds

### DIFF
--- a/build_omaha.py
+++ b/build_omaha.py
@@ -3,7 +3,6 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
-import multiprocessing
 import os
 import os.path
 import shutil
@@ -23,8 +22,7 @@ def build(omaha_dir, standalone_installers_dir, build_all):
   mode = 'opt-win'
   if build_all:
     mode = 'all'
-  command = ['hammer.bat', 'MODE=' + mode, '--all', '--standalone_installers_dir=' + standalone_installers_dir,
-             '-j%d' % multiprocessing.cpu_count()]
+  command = ['hammer.bat', 'MODE=' + mode, '--all', '--standalone_installers_dir=' + standalone_installers_dir]
   if key_pfx_path:
     command.append('--authenticode_file=' + key_pfx_path)
     command.append('--sha1_authenticode_file=' + key_pfx_path)


### PR DESCRIPTION
They give error 3221225477 (=0xc0000005) in CI. Upgrading from Visual Studio 2017 to 2019 did not help. Also using the exact library versions recommended by Omaha did not fix the problem. For now, we have given up on fixing the problem.

Resolves #52 