### PR TITLE
Disable automatic updates

### DIFF
--- a/omaha/base/constants.h
+++ b/omaha/base/constants.h
@@ -430,7 +430,9 @@ const int kSecondsPerDay      = 24 * kSecondsPerHour;
 // hourly mark, the timer interval between updates will have a high likelihood
 // of being satisfied.
 const int kLastCheckJitterSec = 5 * kSecPerMin;
-const int kLastCheckPeriodSec = 5 * kSecondsPerHour - kLastCheckJitterSec;
+
+// We set kLastCheckPeriodSec to 0 to disable automatic updates:
+const int kLastCheckPeriodSec = 0;
 const int kLastCheckPeriodInternalUserSec = kLastCheckPeriodSec / 5;
 
 const int kMinLastCheckPeriodSec = 60;  // 60 seconds minimum.

--- a/omaha/client/ua.cc
+++ b/omaha/client/ua.cc
@@ -145,7 +145,6 @@ bool ShouldCheckForUpdates(bool is_machine) {
   bool is_period_overridden = false;
   const int update_interval = cm->GetLastCheckPeriodSec(&is_period_overridden);
   if (0 == update_interval) {
-    ASSERT1(is_period_overridden);
     OPT_LOG(L1, (_T("[ShouldCheckForUpdates returned 0][checks disabled]")));
     return false;
   }
@@ -161,9 +160,9 @@ bool ShouldCheckForUpdates(bool is_machine) {
     should_check_for_updates = false;
   } else if (update_interval <= time_since_last_check &&
              time_since_last_check < update_interval + kSecondsPerHour) {
-    // Defer some checks if not overridden or if the feature is not disabled.
+    // Defer some checks if the feature is not disabled.
     // Do not skip checks when errors happen in the RNG.
-    if (!is_period_overridden && !IsUpdateAppsHourlyJitterDisabled()) {
+    if (!IsUpdateAppsHourlyJitterDisabled()) {
       const int kPercentageToSkip = 10;    // skip 10% of the checks.
       unsigned int random_value = 0;
       if (!RandUint32(&random_value)) {


### PR DESCRIPTION
This is work towards https://github.com/brave/brave-browser/issues/21745. It disables automatic updates in the updater. To make sure that we still get automatic updates, we would need to extend the browser to schedule update checks while it is running.

After implementing this PR, I realized that its approach may be too limited for rolling out. Consider the following: We deploy this PR as part of a new updater release. The entire fleet gets updated to the new updater. But as described above, for updates to still happen, it needs a new browser version as well. If any users receive the new updater but (for some reason) not the new browser, then they will be stuck on an updater that never checks for updates. I am searching for an alternative solution that does not run into this problem.

The same tests fail as before:

 * ExtractorTest.EmbedExtract
 * ExtractorTest.EmbedAppendExtract
 * ExtractorTest.AlreadyTaggedError
 * TimeTest.RFC822TimeParsing
 * UtilsTest.ReadEntireFile
 * UtilsTest.AddAllowedAce
 * PingTest.BuildOmahaPing
 * PingTest.SendInProcess
 * PingTest.PersistAndSendPersistedPings
 * ScheduledTaskUtilsTest.GoopdateTasks
 * WebServicesClientTest.Send
 * WebServicesClientTest.SendForcingHttps
 * WebServicesClientTest.SendWithCustomHeader
 * WebServicesClientTest.SendStringWithCustomHeader
 * InstallManagerInstallAppMachineTest.InstallApp_MsiInstallerSucceeds
 * InstallManagerInstallAppMachineTest.InstallApp_MsiInstallerWithArgumentSucceeds
 * InstallerWrapperMachineTest.InstallApp_MsiInstallerSucceeds
 * InstallerWrapperMachineTest.InstallApp_MsiInstallerWithArgumentSucceeds
 * WorkerWithTwoAppsTest.CheckForUpdateAsync_Large
 * WorkerWithTwoAppsTest.DownloadAsyncThenDownloadAndInstallAsync_Large
 * CupEcdsaRequestTest.PostSimpleRequest
 * CupEcdsaRequestTest.PostSimpleRequestHttps
 * NetworkRequestTest.MultipleRequests
 * GoogleUpdateRecoveryTest.FixGoogleUpdate_FileReturned_Machine
 * GoogleUpdateRecoveryTest.FixGoogleUpdate_FileReturned_User
 * GoogleUpdateRecoveryTest.FixGoogleUpdate_FileCollision
 * GoogleUpdateRecoveryTest.VerifyFileSignature_SignedValid
 * GoogleUpdateRecoveryTest.VerifyFileSignature_NotSigned
 * GoogleUpdateRecoveryTest.VerifyRepairFileMarkup_InvalidMarkups
 * GoogleUpdateRecoveryTest.ProductionServerResponseTest
 * SetupUserTest.TerminateCoreProcesses_BothTypesRunningAndSimilarArgsProcess
 * SetupMachineTest.StopGoogleUpdateAndWait_ProcessesDoNotStop
 * SetupMachineTest.StopGoogleUpdateAndWait_UserHandoffWorkerRunningAsSystem
 * SetupMachineTest.StopGoogleUpdateAndWait_UserLegacyInstallGoogleUpdateWorkerRunningAsSystem
 * SetupMachineTest.TerminateCoreProcesses_BothTypesRunningAndSimilarArgsProcess
 * UnitTestHelpersTest.ClearGroupPolicies
 * IsForeground/WebServicesClientTest.SendUsingCup/0, where GetParam() = false
 * IsForeground/WebServicesClientTest.SendUsingCup/1, where GetParam() = true
 * IsForeground/WebServicesClientTest.SendString/0, where GetParam() = false
 * IsForeground/WebServicesClientTest.SendString/1, where GetParam() = true
 * IsMachine/InstallManagerTest.InstallDir_ReadOnlyFiles/1, where GetParam() = true