### PR TITLE
Pick the Authenticode signing certificate by hash

### DIFF
--- a/build_omaha.py
+++ b/build_omaha.py
@@ -36,6 +36,8 @@ def build(omaha_dir, standalone_installers_dir, build_all):
     command.append('--authenticode_hash=' + authenticode_hash)
     command.append('--sha1_authenticode_hash=' + authenticode_hash)
     command.append('--sha2_authenticode_hash=' + authenticode_hash)
+    # Our certs identified by hash are always in the machine store:
+    command.append('--use_authenticode_machine_store')
 
   # Pick signtool.exe from PATH. This in particular ensures that we use the same
   # signtool as Chromium, which is 64 bit and thus has access to the same certs.

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -36,6 +36,14 @@ def build(omaha_dir, standalone_installers_dir, build_all):
     command.append('--authenticode_hash=' + authenticode_hash)
     command.append('--sha1_authenticode_hash=' + authenticode_hash)
     command.append('--sha2_authenticode_hash=' + authenticode_hash)
+
+  # Pick signtool.exe from PATH. This in particular ensures that we use the same
+  # signtool as Chromium, which is 64 bit and thus has access to the same certs.
+  env = dict(os.environ)
+  signtool_path = shutil.which('signtool.exe')
+  assert signtool_path, 'signtool.exe is expected to be on PATH'
+  env['OMAHA_SIGNTOOL_SDK_DIR'] = os.path.dirname(signtool_path)
+
   sp.check_call(command, stderr=sp.STDOUT)
 
 def copy_untagged_installers(args, omaha_dir, debug):

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -46,7 +46,7 @@ def build(omaha_dir, standalone_installers_dir, build_all):
   assert signtool_path, 'signtool.exe is expected to be on PATH'
   env['OMAHA_SIGNTOOL_SDK_DIR'] = os.path.dirname(signtool_path)
 
-  sp.check_call(command, stderr=sp.STDOUT)
+  sp.check_call(command, stderr=sp.STDOUT, env=env)
 
 def copy_untagged_installers(args, omaha_dir, debug):
   omaha_out_dir = get_omaha_out_dir(omaha_dir, debug)

--- a/build_omaha.py
+++ b/build_omaha.py
@@ -18,6 +18,7 @@ def build(omaha_dir, standalone_installers_dir, build_all):
   key_pfx_path = os.environ.get('KEY_PFX_PATH', '')
   key_cer_path = os.environ.get('KEY_CER_PATH', '')
   authenticode_password = os.environ.get('AUTHENTICODE_PASSWORD', '')
+  authenticode_hash = os.environ.get('AUTHENTICODE_HASH', '')
 
   mode = 'opt-win'
   if build_all:
@@ -31,6 +32,10 @@ def build(omaha_dir, standalone_installers_dir, build_all):
     command.append('--authenticode_password=' + authenticode_password)
     command.append('--sha1_authenticode_password=' + authenticode_password)
     command.append('--sha2_authenticode_password=' + authenticode_password)
+  if authenticode_hash:
+    command.append('--authenticode_hash=' + authenticode_hash)
+    command.append('--sha1_authenticode_hash=' + authenticode_hash)
+    command.append('--sha2_authenticode_hash=' + authenticode_hash)
   sp.check_call(command, stderr=sp.STDOUT)
 
 def copy_untagged_installers(args, omaha_dir, debug):

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -160,6 +160,10 @@ win_env['ENV']['LocalAppData'] = os.getenv('LocalAppData')
 # Append paths for supporting tools such as uuidgen.exe.
 win_env.AppendENVPath('PATH', (os.environ['WindowsSdkVerBinPath'] + '\\x86\\'))
 
+if os.getenv('n3fips_password'):
+    # Forward this env. var, which is used for CloudHSM code signing.
+    win_env['ENV']['n3fips_password'] = os.getenv('n3fips_password')
+
 # Remove this value because it conflicts with a #define
 # in shlwapi.h in the Vista SDK
 win_env.FilterOut(CPPDEFINES = ['OS_WINDOWS=OS_WINDOWS'])

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -321,6 +321,8 @@ DeclareBit('has_device_management',
            'True if including cloud-based device management')
 DeclareBit('verify_payload_authenticode_signature',
            'Whether to verify the Authenticode signature of payloads')
+DeclareBit('use_authenticode_machine_store',
+           'Use the machine store, instead of the user store, of certificates')
 
 # Build official installers if --official_installers is on the command line.
 win_env.SetBitFromOption('official_installers', False)
@@ -420,6 +422,9 @@ win_env.SetBitFromOption('suppress_light_validation', False)
 
 # Whether the Authenticode signature of update payloads should be verified.
 win_env.SetBitFromOption('verify_payload_authenticode_signature', False)
+
+# Whether to use the machine store instead of the user store for certificates.
+win_env.SetBitFromOption('use_authenticode_machine_store', False)
 
 #
 # Set up version info.
@@ -983,6 +988,8 @@ def SigningCommand(env, filename):
     # Add cert hash if any.
     if env.subst('$CERTIFICATE_HASH'):
       signing_cmd += ' /sha1 "$CERTIFICATE_HASH"'
+    if env.Bit('use_authenticode_machine_store'):
+      signing_cmd += ' /sm'
     # Add timestamp server if any.
     if env.subst('$TIMESTAMP_SERVER'):
       signing_cmd += ' /t "$TIMESTAMP_SERVER"'

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -187,7 +187,7 @@ AddOption(
     action='store',
     nargs=1,
     type='string',
-    default='$MAIN_DIR/data/OmahaTestCert.pfx'
+    default=None
 )
 
 default_cert_password = 'test'
@@ -196,7 +196,31 @@ AddOption(
     action='store',
     nargs=1,
     type='string',
-    default=default_cert_password
+    default=None
+)
+
+AddOption(
+    '--authenticode_hash',
+    action='store',
+    nargs=1,
+    type='string',
+    default=None
+)
+
+AddOption(
+    '--sha1_authenticode_hash',
+    action='store',
+    nargs=1,
+    type='string',
+    default=None
+)
+
+AddOption(
+    '--sha2_authenticode_hash',
+    action='store',
+    nargs=1,
+    type='string',
+    default=None
 )
 
 AddOption(
@@ -204,7 +228,7 @@ AddOption(
     action='store',
     nargs=1,
     type='string',
-    default='$MAIN_DIR/data/Sha1OmahaTestCert.pfx'
+    default=None
 )
 
 default_sha1_cert_password = '888'
@@ -213,7 +237,7 @@ AddOption(
     action='store',
     nargs=1,
     type='string',
-    default=default_sha1_cert_password
+    default=None
 )
 
 AddOption(
@@ -221,7 +245,7 @@ AddOption(
     action='store',
     nargs=1,
     type='string',
-    default='$MAIN_DIR/data/Sha2OmahaTestCert.pfx'
+    default=None
 )
 
 default_sha2_cert_password = '888'
@@ -230,7 +254,7 @@ AddOption(
     action='store',
     nargs=1,
     type='string',
-    default=default_sha2_cert_password
+    default=None
 )
 
 # Declare option for specifying path to new official build files
@@ -347,24 +371,42 @@ if win_env.Bit('build_three_versions'):
 # Allow use of command-line-specified certificates to sign with, but
 # only if we're not on the build server.
 if not win_env.Bit('build_server'):
+  _authenticode_hash = GetOption('authenticode_hash')
+  _authenticode_file = GetOption('authenticode_file')
+  _authenticode_password = GetOption('authenticode_password')
+  if not _authenticode_hash and not _authenticode_file:
+    assert not _authenticode_password
+    win_env.SetBits('test_certificate')
+    _authenticode_file = '$MAIN_DIR/data/OmahaTestCert.pfx'
+    _authenticode_password = default_cert_password
+
+  _sha1_authenticode_hash = GetOption('sha1_authenticode_hash')
+  _sha2_authenticode_hash = GetOption('sha2_authenticode_hash')
+  _sha1_authenticode_file = GetOption('sha1_authenticode_file')
+  _sha2_authenticode_file = GetOption('sha2_authenticode_file')
+  _sha1_authenticode_password = GetOption('sha1_authenticode_password')
+  _sha2_authenticode_password = GetOption('sha2_authenticode_password')
+  if not _sha1_authenticode_hash and not _sha2_authenticode_hash \
+    and not _sha1_authenticode_file and not _sha2_authenticode_file:
+    assert not _sha1_authenticode_password and not _sha2_authenticode_password
+    _sha1_authenticode_file = '$MAIN_DIR/data/Sha1OmahaTestCert.pfx'
+    _sha2_authenticode_file = '$MAIN_DIR/data/Sha2OmahaTestCert.pfx'
+    _sha1_authenticode_password = default_sha1_cert_password
+    _sha2_authenticode_password = default_sha2_cert_password
+
   win_env.Replace(
-    CERTIFICATE_HASH='',
-    CERTIFICATE_PASSWORD=GetOption('authenticode_password'),
-    CERTIFICATE_PATH=GetOption('authenticode_file'),
-    SHA1_CERTIFICATE_HASH='',
-    SHA2_CERTIFICATE_HASH='',
+    CERTIFICATE_HASH=_authenticode_hash,
+    CERTIFICATE_PASSWORD=_authenticode_password,
+    CERTIFICATE_PATH=_authenticode_file,
+    SHA1_CERTIFICATE_HASH=_sha1_authenticode_hash,
+    SHA2_CERTIFICATE_HASH=_sha2_authenticode_hash,
     SHA1_CERTIFICATE_ISSUER='',
     SHA2_CERTIFICATE_ISSUER='',
-    SHA1_CERTIFICATE_PASSWORD=GetOption('sha1_authenticode_password'),
-    SHA2_CERTIFICATE_PASSWORD=GetOption('sha2_authenticode_password'),
-    SHA1_CERTIFICATE_PATH=GetOption('sha1_authenticode_file'),
-    SHA2_CERTIFICATE_PATH=GetOption('sha2_authenticode_file'),
+    SHA1_CERTIFICATE_PASSWORD=_sha1_authenticode_password,
+    SHA2_CERTIFICATE_PASSWORD=_sha2_authenticode_password,
+    SHA1_CERTIFICATE_PATH=_sha1_authenticode_file,
+    SHA2_CERTIFICATE_PATH=_sha2_authenticode_file,
   )
-
-  # Store whether we're using the default test cert separately, because
-  # we won't always know what the default password was.
-  if GetOption('authenticode_password') is default_cert_password:
-    win_env.SetBits('test_certificate')
 
 # Build the 64 bit version of the code.
 win_env.SetBitFromOption('x64', False)
@@ -924,7 +966,8 @@ windows_coverage_env['SIGNTOOL'] = '@echo Signing deferred: '
 
 def SigningCommand(env, filename):
   # Only do signing if there is a certificate file or certificate name.
-  if env.subst('$CERTIFICATE_PATH') or env.subst('$CERTIFICATE_NAME'):
+  if env.subst('$CERTIFICATE_PATH') or env.subst('$CERTIFICATE_NAME') \
+      or env.subst('$CERTIFICATE_HASH'):
     # The command used to do signing (target added on below).
     signing_cmd = '$SIGNTOOL_ORIG sign '
     # Add in certificate file if any.
@@ -937,6 +980,9 @@ def SigningCommand(env, filename):
     if env.subst('$CERTIFICATE_NAME'):
       # The command used to do signing (target added on below).
       signing_cmd += ' /s "$CERTIFICATE_STORE" /n "$CERTIFICATE_NAME"'
+    # Add cert hash if any.
+    if env.subst('$CERTIFICATE_HASH'):
+      signing_cmd += ' /sha1 "$CERTIFICATE_HASH"'
     # Add timestamp server if any.
     if env.subst('$TIMESTAMP_SERVER'):
       signing_cmd += ' /t "$TIMESTAMP_SERVER"'

--- a/omaha/site_scons/site_tools/code_signing.py
+++ b/omaha/site_scons/site_tools/code_signing.py
@@ -124,6 +124,8 @@ def SignedBinaryGenerator(source, target, env, for_signature):
     # Add cert hash if any.
     if env.subst('$CERTIFICATE_HASH'):
       signing_cmd += ' /sha1 "$CERTIFICATE_HASH"'
+    if env.Bit('use_authenticode_machine_store'):
+      signing_cmd += ' /sm'
     # Add timestamp server if any.
     if env.subst('$TIMESTAMP_SERVER'):
       signing_cmd += ' /t "$TIMESTAMP_SERVER"'
@@ -180,6 +182,8 @@ def DualSignedBinaryGenerator(source, target, env, for_signature):
     # Add cert hash if any.
     if env.subst('$SHA1_CERTIFICATE_HASH'):
       sha1_signing_cmd += ' /sha1 "$SHA1_CERTIFICATE_HASH"'
+    if env.Bit('use_authenticode_machine_store'):
+      sha1_signing_cmd += ' /sm'
     # Add in target name
     sha1_signing_cmd += ' "$TARGET"'
     # Add the SHA1 signing to the list of commands to perform.
@@ -205,6 +209,8 @@ def DualSignedBinaryGenerator(source, target, env, for_signature):
     # Add cert hash if any.
     if env.subst('$SHA2_CERTIFICATE_HASH'):
       sha2_signing_cmd += ' /sha1 "$SHA2_CERTIFICATE_HASH"'
+    if env.Bit('use_authenticode_machine_store'):
+      sha2_signing_cmd += ' /sm'
     # Other options needed when adding a second, sha2 signature.
     sha2_signing_cmd += ' /as /fd "SHA256"'
     # Add in target name

--- a/omaha/site_scons/site_tools/code_signing.py
+++ b/omaha/site_scons/site_tools/code_signing.py
@@ -107,7 +107,8 @@ def SignedBinaryGenerator(source, target, env, for_signature):
   ]
 
   # Only do signing if there is a certificate file or certificate name.
-  if env.subst('$CERTIFICATE_PATH') or env.subst('$CERTIFICATE_NAME'):
+  if env.subst('$CERTIFICATE_PATH') or env.subst('$CERTIFICATE_NAME') \
+      or env.subst('$CERTIFICATE_HASH'):
     # The command used to do signing (target added on below).
     signing_cmd = '$SIGNTOOL sign /fd sha1'
     # Add in certificate file if any.
@@ -148,7 +149,9 @@ def DualSignedBinaryGenerator(source, target, env, for_signature):
   # Only do signing if there are certificate files or a certificate name. The
   # CERTIFICATE_NAME is expected to be the same for both SHA1 and SHA2.
   if (env.subst('$SHA1_CERTIFICATE_PATH') and
-      env.subst('$SHA2_CERTIFICATE_PATH')) or env.subst('$CERTIFICATE_NAME'):
+      env.subst('$SHA2_CERTIFICATE_PATH')) or \
+     (env.subst('$SHA1_CERTIFICATE_HASH') and
+      env.subst('$SHA2_CERTIFICATE_HASH')) or env.subst('$CERTIFICATE_NAME'):
     # Setup common signing command options (same as single signing).
     base_signing_cmd = '$SIGNTOOL sign /v '
     # Add certificate store if any.


### PR DESCRIPTION
This lets us use non-file based certificates and prevents ambiguities with multiple certificates with a similar Subject name.