### PR TITLE
Bump version to 1.3.361.133

### DIFF
--- a/omaha/VERSION
+++ b/omaha/VERSION
@@ -5,4 +5,4 @@
 version_major = 1    # 1-65535
 version_minor = 3    # 0-65535
 version_build = 361   # 1-65535
-version_patch = 131    # 0-65535
+version_patch = 133    # 0-65535


### PR DESCRIPTION
This lets us roll out a version of Omaha to the fleet that's signed with our new Authenticode certificate.