### PR TITLE
Add support for Arm64 Windows

### DIFF
--- a/omaha/VERSION
+++ b/omaha/VERSION
@@ -5,4 +5,4 @@
 version_major = 1    # 1-65535
 version_minor = 3    # 0-65535
 version_build = 361   # 1-65535
-version_patch = 133    # 0-65535
+version_patch = 135    # 0-65535

--- a/omaha/base/constants.h
+++ b/omaha/base/constants.h
@@ -120,17 +120,22 @@ const TCHAR* const kOmahaBrokerFileName        =
     MAIN_EXE_BASE_NAME _T("Broker.exe");
 const TCHAR* const kOmahaOnDemandFileName      =
     MAIN_EXE_BASE_NAME _T("OnDemand.exe");
-const TCHAR* const kCrashHandlerFileName   = CRASH_HANDLER_NAME _T(".exe");
-const TCHAR* const kCrashHandler64FileName = CRASH_HANDLER_NAME _T("64.exe");
+const TCHAR* const kCrashHandlerFileName       = CRASH_HANDLER_NAME _T(".exe");
+const TCHAR* const kCrashHandler64FileName     = CRASH_HANDLER_NAME _T("64.exe");
+const TCHAR* const kCrashHandlerArm64FileName  = CRASH_HANDLER_NAME _T("Arm64.exe");
 const TCHAR* const kOmahaMetainstallerFileName =
     MAIN_EXE_BASE_NAME _T("Setup.exe");
 const TCHAR* const kOmahaCOMRegisterShell64    =
     MAIN_EXE_BASE_NAME _T("ComRegisterShell64.exe");
-const TCHAR* const kOmahaCoreFileName  = MAIN_EXE_BASE_NAME _T("Core.exe");
-const TCHAR* const kPSFileNameMachine  = _T("psmachine.dll");
-const TCHAR* const kPSFileNameMachine64= _T("psmachine_64.dll");
-const TCHAR* const kPSFileNameUser     = _T("psuser.dll");
-const TCHAR* const kPSFileNameUser64   = _T("psuser_64.dll");
+const TCHAR* const kOmahaCOMRegisterShellArm64    =
+    MAIN_EXE_BASE_NAME _T("ComRegisterShellArm64.exe");
+const TCHAR* const kOmahaCoreFileName      = MAIN_EXE_BASE_NAME _T("Core.exe");
+const TCHAR* const kPSFileNameMachine      = _T("psmachine.dll");
+const TCHAR* const kPSFileNameMachine64    = _T("psmachine_64.dll");
+const TCHAR* const kPSFileNameMachineArm64 = _T("psmachine_arm64.dll");
+const TCHAR* const kPSFileNameUser         = _T("psuser.dll");
+const TCHAR* const kPSFileNameUser64       = _T("psuser_64.dll");
+const TCHAR* const kPSFileNameUserArm64    = _T("psuser_arm64.dll");
 
 // TODO(omaha): Replace the following literal in clickonce\build.scons.
 // '%s/GoogleUpdateSetup.exe'

--- a/omaha/base/dynamic_link_kernel32.cc
+++ b/omaha/base/dynamic_link_kernel32.cc
@@ -26,6 +26,7 @@ typedef BOOL (WINAPI * Module32NextFunc)(HANDLE, LPMODULEENTRY32);
 typedef BOOL (WINAPI * Process32FirstFunc)(HANDLE, LPPROCESSENTRY32);
 typedef BOOL (WINAPI * Process32NextFunc)(HANDLE, LPPROCESSENTRY32);
 typedef BOOL (WINAPI * IsWow64ProcessFunc)(HANDLE, PBOOL);
+typedef BOOL (WINAPI * IsWow64Process2Func)(HANDLE, USHORT*, USHORT*);
 
 #define kKernel32Module L"kernel32"
 
@@ -102,6 +103,23 @@ BOOL WINAPI Kernel32::IsWow64Process(HANDLE hProcess, PBOOL Wow64Process) {
     return FALSE;
 
   return f(hProcess, Wow64Process);
+}
+
+BOOL WINAPI Kernel32::IsWow64Process2(HANDLE hProcess,
+                                      USHORT* pProcessMachine,
+                                      USHORT* pNativeMachine) {
+  static IsWow64Process2Func f = NULL;
+
+  if (f == NULL) {
+    HMODULE handle = GetModuleHandle(kKernel32Module);
+    ASSERT(handle, (L""));
+    f = (IsWow64Process2Func) GetProcAddress(handle, "IsWow64Process2");
+  }
+
+  if (f == NULL)
+    return FALSE;
+
+  return f(hProcess, pProcessMachine, pNativeMachine);
 }
 
 }  // namespace omaha

--- a/omaha/base/dynamic_link_kernel32.h
+++ b/omaha/base/dynamic_link_kernel32.h
@@ -36,6 +36,9 @@ class Kernel32 {
   // Is process running under WOW64?
   // WOW64 is the emulator for win32 applications running on win64.
   static BOOL WINAPI IsWow64Process(HANDLE hProcess, PBOOL Wow64Process);
+  static BOOL WINAPI IsWow64Process2(HANDLE hProcess,
+                                     USHORT *pProcessMachine,
+                                     USHORT *pNativeMachine);
 
  private:
   DISALLOW_COPY_AND_ASSIGN(Kernel32);

--- a/omaha/base/timer.h
+++ b/omaha/base/timer.h
@@ -119,7 +119,16 @@ class Timer {
 };
 
 // lint -e{31}   Redefinition of symbol
-__forceinline time64 Timer::GetRdtscCounter() { return __rdtsc(); }
+__forceinline time64 Timer::GetRdtscCounter() {
+#ifdef ARCH_CPU_ARM64
+  // Note: This simple implementation likely has the limitations described in
+  // https://chromium.googlesource.com/chromium/src/+/
+  // a98d8582f91cf62b463d1bca585476726496ce2a%5E%21/.
+  return _ReadStatusReg(ARM64_PMCCNTR_EL0);
+#else
+  return __rdtsc();
+#endif
+}
 
 inline double Timer::PerfCountToNanoSeconds(time64 perf_count) const {
   return (static_cast<double>(perf_count) / static_cast<double>(count_freq_)) *

--- a/omaha/common/build.scons
+++ b/omaha/common/build.scons
@@ -51,10 +51,17 @@ def BuildCommonLib(env):
       local_env.GetMultiarchLibName('statsreport'),   # Required by common
       ]
 
-  lib_name = 'common%s' % ('', '_64')[local_env.Bit('x64')]
+  if local_env.Bit('x64'):
+    suffix = '_64'
+  elif local_env.Bit('arm64'):
+    suffix = '_arm64'
+  else:
+    suffix = ''
+  lib_name = 'common' + suffix
 
   # Build these into a library.
   local_env.ComponentLibrary(lib_name, inputs)
 
 BuildCommonLib(env)
 BuildCommonLib(env.CloneAndMake64Bit())
+BuildCommonLib(env.CloneAndMakeArm64Bit())

--- a/omaha/common/goopdate_utils.h
+++ b/omaha/common/goopdate_utils.h
@@ -71,7 +71,9 @@ CString BuildGoogleUpdateExePath(bool is_machine);
 CString BuildGoogleUpdateServicesPath(bool is_machine, bool use64bit);
 
 // Builds the path of the crash handler and adds the enclosing quotes.
-CString BuildGoogleUpdateServicesEnclosedPath(bool is_machine, bool use64bit);
+CString BuildGoogleUpdateServicesEnclosedPath(bool is_machine,
+                                              bool use64bit,
+                                              bool useArm64bit);
 
 // Returns true if the currently executing binary is running from the
 // Machine/User Goopdate directory, or a directory under it.

--- a/omaha/common/xml_const.cc
+++ b/omaha/common/xml_const.cc
@@ -157,6 +157,7 @@ const TCHAR* const kAppDefinedPrefix = _T("_");
 namespace value {
 
 const TCHAR* const kArchAmd64 = _T("x64");
+const TCHAR* const kArchArm64 = _T("arm64");
 const TCHAR* const kArchIntel = _T("x86");
 const TCHAR* const kArchUnknown = _T("unknown");
 const TCHAR* const kBits = _T("bits");

--- a/omaha/common/xml_const.h
+++ b/omaha/common/xml_const.h
@@ -157,6 +157,7 @@ extern const TCHAR* const kAppDefinedPrefix;
 namespace value {
 
 extern const TCHAR* const kArchAmd64;
+extern const TCHAR* const kArchArm64;
 extern const TCHAR* const kArchIntel;
 extern const TCHAR* const kArchUnknown;
 extern const TCHAR* const kBits;

--- a/omaha/common/xml_parser.cc
+++ b/omaha/common/xml_parser.cc
@@ -154,6 +154,9 @@ CString ConvertProcessorArchitectureToString(DWORD arch) {
     case PROCESSOR_ARCHITECTURE_AMD64:
       return xml::value::kArchAmd64;
 
+    case PROCESSOR_ARCHITECTURE_ARM64:
+      return xml::value::kArchArm64;
+
     default:
       ASSERT1(false);
       return xml::value::kArchUnknown;

--- a/omaha/crashhandler/build.scons
+++ b/omaha/crashhandler/build.scons
@@ -54,7 +54,13 @@ def BuildCrashHandler(local_env):
           lib_env.GetMultiarchLibName('statsreport'),
           ]
   )
-  lib_name = 'crash_handler%s' % ('', '_64')[lib_env.Bit('x64')]
+  if local_env.Bit('x64'):
+    lib_suffix = '_64'
+  elif local_env.Bit('arm64'):
+    lib_suffix = '_arm64'
+  else:
+    lib_suffix = ''
+  lib_name = 'crash_handler' + lib_suffix
   library_crash_handler = lib_env.ComponentLibrary(
       lib_name,
       lib_inputs
@@ -102,7 +108,13 @@ def BuildCrashHandler(local_env):
         ],
   )
 
-  gch_res_target = 'resource%s.res' % ('','64')[gch_env.Bit('x64')]
+  if local_env.Bit('x64'):
+    res_suffix = '64'
+  elif local_env.Bit('arm64'):
+    res_suffix = 'arm64'
+  else:
+    res_suffix = ''
+  gch_res_target = 'resource%s.res' % res_suffix
   gch_res = gch_env.RES(source = 'resource.rc', target = gch_res_target)
   gch_env.Depends(gch_res, 'GoogleCrashHandler.manifest')
 
@@ -113,7 +125,7 @@ def BuildCrashHandler(local_env):
 
   # Change the name of the executable based on the architecture, and
   # change the names of the objects to prevent collisions.
-  exe_name = 'BraveCrashHandler%s' % ('', '64')[gch_env.Bit('x64')]
+  exe_name = 'BraveCrashHandler%s' % res_suffix.title()
   unsigned_crash_handler = gch_env.ComponentProgram(
       prog_name='%s_unsigned.exe' % exe_name,
       source=gch_inputs,
@@ -165,5 +177,6 @@ def BuildCrashAnalysisTest(local_env):
 
 BuildCrashHandler(env)
 BuildCrashHandler(env.CloneAndMake64Bit())
+BuildCrashHandler(env.CloneAndMakeArm64Bit())
 
 BuildCrashAnalysisTest(env)

--- a/omaha/goopdate/build.scons
+++ b/omaha/goopdate/build.scons
@@ -77,8 +77,18 @@ def BuildCOMForwarder(cmd_line_switch,
 BuildCOMForwarder('/broker', 'BraveUpdateBroker', False)
 BuildCOMForwarder('/ondemand', 'BraveUpdateOnDemand', False)
 
+
 def BuildCOMRegisterShell64():
   com_register_shell_env = env.CloneAndMake64Bit()
+  BuildCOMRegisterShellNon32Bit(com_register_shell_env, '64')
+
+
+def BuildCOMRegisterShellArm64():
+  com_register_shell_env = env.CloneAndMakeArm64Bit()
+  BuildCOMRegisterShellNon32Bit(com_register_shell_env, 'arm64')
+
+
+def BuildCOMRegisterShellNon32Bit(com_register_shell_env, suffix):
   com_register_shell_env.FilterOut(CCFLAGS=['/GL', '/RTC1',])
   com_register_shell_env.FilterOut(LINKFLAGS=['/LTCG'])
 
@@ -90,10 +100,10 @@ def BuildCOMRegisterShell64():
           '/ENTRY:WinMainCRTStartup',
       ],
       LIBS=[
-          '$LIB_DIR/base_64.lib',
-          '$LIB_DIR/common_64.lib',
-          '$LIB_DIR/logging_64.lib',
-          '$LIB_DIR/goopdate_lib_64.lib',
+          '$LIB_DIR/base_%s.lib' % suffix,
+          '$LIB_DIR/common_%s.lib' % suffix,
+          '$LIB_DIR/logging_%s.lib' % suffix,
+          '$LIB_DIR/goopdate_lib_%s.lib' % suffix,
           com_register_shell_env['atls_libs'][
               com_register_shell_env.Bit('debug')
           ],
@@ -111,25 +121,26 @@ def BuildCOMRegisterShell64():
   if env.Bit('has_device_management'):
     com_register_shell_env.Append(
         LIBS=[
-            '$LIB_DIR/dm_proto_64.lib',
-            '$LIB_DIR/libprotobuf_64.lib',
+            '$LIB_DIR/dm_proto_%s.lib' % suffix,
+            '$LIB_DIR/libprotobuf_%s.lib' % suffix,
         ],
     )
 
   unsigned_exe = com_register_shell_env.ComponentProgram(
-      prog_name='BraveUpdateComRegisterShell64_unsigned',
+      prog_name='BraveUpdateComRegisterShell%s_unsigned' % suffix.title(),
       source= [
           'com_register_shell.cc',
           ]
   )
   signed_exe = com_register_shell_env.DualSignedBinary(
-      target='BraveUpdateComRegisterShell64.exe',
+      target='BraveUpdateComRegisterShell%s.exe' % suffix.title(),
       source=unsigned_exe,
   )
   env.Replicate('$STAGING_DIR', signed_exe)
 
 # Build the COM register shell.
 BuildCOMRegisterShell64()
+BuildCOMRegisterShellArm64()
 
 #
 # Generate omaha3_idl.idl. The output is an IDL file with a variant CLSID
@@ -152,13 +163,21 @@ def BuildGoogleUpdateCOMProxy(midl_env, generated_idl):
       '/Oicf',  # generate optimized stubless proxy/stub code
       ]
 
-  suffix = ('', '_64')[midl_env.Bit('x64')]
   if midl_env.Bit('x64'):
-    midl_env['MIDLFLAGS'] += [ '/amd64' ]
+    suffix = '_64'
+    midlflags = '/amd64'
+  elif midl_env.Bit('arm64'):
+    suffix = '_arm64'
+    midlflags = '/arm64'
+  else:
+    suffix = ''
+
+  if suffix:
+    midl_env['MIDLFLAGS'] += [ midlflags ]
 
     # Make a copy of the IDL file with different name so the output won't
     # collide with the output from 32-bit version IDL.
-    target_idl = 'omaha3_idl_64.idl',
+    target_idl = 'omaha3_idl%s.idl' % suffix,
     midl_env.Command(target_idl, 'omaha3_idl.idl', Copy('$TARGET', '$SOURCE'))
     midl_env.TypeLibrary(target_idl)
   else:
@@ -186,6 +205,7 @@ def BuildGoogleUpdateCOMProxy(midl_env, generated_idl):
 generated_omaha3_idl = GenerateOmaha3IDLFile()
 BuildGoogleUpdateCOMProxy(env.Clone(), generated_omaha3_idl)
 BuildGoogleUpdateCOMProxy(env.CloneAndMake64Bit(), generated_omaha3_idl)
+BuildGoogleUpdateCOMProxy(env.CloneAndMakeArm64Bit(), generated_omaha3_idl)
 
 def BuildGoogleUpdateHandlerDll(handler_env,
                                 omaha_version_info,
@@ -251,7 +271,13 @@ def BuildGoogleUpdateHandlerDll(handler_env,
       ],
   )
 
-  suffix = ('', '_64')[handler_env.Bit('x64')]
+  if handler_env.Bit('x64'):
+    suffix = '_64'
+  elif handler_env.Bit('arm64'):
+    suffix = '_arm64'
+  else:
+    suffix = ''
+
   resource = handler_env.RES(
       target='%s%s_resource%s.res' % (prefix, psname, suffix),
       source='google_update_ps_resource.rc')
@@ -292,9 +318,13 @@ for omaha_version_info in env['omaha_versions_info']:
                               omaha_version_info, 1, 'psmachine')
   BuildGoogleUpdateHandlerDll(handler_env.CloneAndMake64Bit(),
                               omaha_version_info, 1, 'psmachine')
+  BuildGoogleUpdateHandlerDll(handler_env.CloneAndMakeArm64Bit(),
+                              omaha_version_info, 1, 'psmachine')
   BuildGoogleUpdateHandlerDll(handler_env.Clone(),
                               omaha_version_info, 0, 'psuser')
   BuildGoogleUpdateHandlerDll(handler_env.CloneAndMake64Bit(),
+                              omaha_version_info, 0, 'psuser')
+  BuildGoogleUpdateHandlerDll(handler_env.CloneAndMakeArm64Bit(),
                               omaha_version_info, 0, 'psuser')
 
 if env.Bit('has_device_management'):

--- a/omaha/goopdate/com_register_shell.cc
+++ b/omaha/goopdate/com_register_shell.cc
@@ -81,7 +81,15 @@ HRESULT RegisterOrUnregisterProxies64(bool is_machine, bool is_register) {
   ON_SCOPE_EXIT(goopdate_utils::RemoveRedirectHKCR);
 
   CPath ps_dll(app_util::GetCurrentModuleDirectory());
-  if (!ps_dll.Append(is_machine ? kPSFileNameMachine64 : kPSFileNameUser64)) {
+
+  const TCHAR* const psFileName =
+#ifdef ARCH_CPU_ARM64
+      is_machine ? kPSFileNameMachineArm64 : kPSFileNameUserArm64;
+#else
+      is_machine ? kPSFileNameMachine64 : kPSFileNameUser64;
+#endif
+
+  if (!ps_dll.Append(psFileName)) {
     return HRESULTFromLastError();
   }
 

--- a/omaha/goopdate/dm_client.cc
+++ b/omaha/goopdate/dm_client.cc
@@ -408,7 +408,9 @@ CString GetPlatform() {
                         _T("x86_64") :
                         (architecture == PROCESSOR_ARCHITECTURE_INTEL ?
                              _T("x86") :
-                             _T("")),
+                             architecture == PROCESSOR_ARCHITECTURE_ARM64 ?
+                                  _T("arm64") :
+                                  _T("")),
                     major_version, minor_version);
   return platform;
 }

--- a/omaha/goopdate/omaha3_idl_datax.c
+++ b/omaha/goopdate/omaha3_idl_datax.c
@@ -41,7 +41,10 @@
 #define DLLDUMMYPURECALL
 #endif
 
-#ifndef _M_AMD64
+#ifdef ARCH_CPU_ARM64
+  #include "goopdate/omaha3_idl_arm64_data.c"
+  #include "goopdate/omaha3_idl_arm64_p.c"
+#elif !defined(_M_AMD64)
   #include "goopdate/omaha3_idl_data.c"
   #include "goopdate/omaha3_idl_p.c"
 #else

--- a/omaha/goopdate/update_response_utils.cc
+++ b/omaha/goopdate/update_response_utils.cc
@@ -64,7 +64,11 @@ bool IsArchCompatible(const CString& arch) {
   return arch.IsEmpty() ||
          !arch.CompareNoCase(current_arch) ||
          (arch == xml::value::kArchIntel &&
-         current_arch == xml::value::kArchAmd64);
+         current_arch == xml::value::kArchAmd64) ||
+         (arch == xml::value::kArchIntel &&
+         current_arch == xml::value::kArchArm64) ||
+         (arch == xml::value::kArchAmd64 &&
+         current_arch == xml::value::kArchArm64);;
 }
 
 bool IsOSVersionCompatible(const CString& min_os_version) {

--- a/omaha/main.scons
+++ b/omaha/main.scons
@@ -319,6 +319,7 @@ DeclareBit('all', 'Building all Projects')
 DeclareBit('msvs', 'Building Visual Studio solution files')
 DeclareBit('no-tests', 'Do not build the unit tests')
 DeclareBit('x64', 'Build 64 bit code')
+DeclareBit('arm64', 'Build 64 bit ARM code')
 DeclareBit('analysis', 'Turns on static analysis')
 DeclareBit('suppress_light_validation', 'Suppress WiX Linker ICE validation')
 DeclareBit('has_device_management',

--- a/omaha/omaha_version_utils.py
+++ b/omaha/omaha_version_utils.py
@@ -166,6 +166,15 @@ def _GetMetainstallerPayloadFilenames(prefix,
     # GoogleUpdateHelper.msi was removed with version 1.3.36.61.
     payload_files.remove('%sHelper.msi' % _MAIN_EXE_BASE_NAME)
 
+  if (omaha_version[0] >= 1 and
+      omaha_version[1] >= 3 and
+      (omaha_version[2] > 361 or
+       (omaha_version[2] == 361 and omaha_version[3] >= 135))):
+    payload_files += ['%sArm64.exe' % _CRASH_HANDLER_NAME,
+                      '%sComRegisterShellArm64.exe' % _MAIN_EXE_BASE_NAME,
+                      '%spsmachine_arm64.dll' % (prefix),
+                      '%spsuser_arm64.dll' % (prefix),]
+
   for language in languages:
     payload_files += ['%sgoopdateres_%s.dll' % (prefix, language)]
 

--- a/omaha/setup/setup.cc
+++ b/omaha/setup/setup.cc
@@ -972,6 +972,7 @@ HRESULT Setup::GetPidsToWaitForUsingCommandLine(Pids* pids) const {
   const TCHAR* kCrashHandlerFileNames[] = {
     kCrashHandlerFileName,
     kCrashHandler64FileName,
+    kCrashHandlerArm64FileName,
   };
   for (size_t i = 0; i < arraysize(kCrashHandlerFileNames); ++i) {
     std::vector<uint32> matching_pids;

--- a/omaha/setup/setup_files.cc
+++ b/omaha/setup/setup_files.cc
@@ -302,7 +302,9 @@ HRESULT SetupFiles::BuildFileLists() {
   core_program_files_.push_back(kOmahaCoreFileName);
   core_program_files_.push_back(kCrashHandlerFileName);
   core_program_files_.push_back(kCrashHandler64FileName);
+  core_program_files_.push_back(kCrashHandlerArm64FileName);
   core_program_files_.push_back(kOmahaCOMRegisterShell64);
+  core_program_files_.push_back(kOmahaCOMRegisterShellArm64);
 
   // TODO(omaha3): Try to not depend on ResourceManager. Maybe just find the
   // files using wildcards.
@@ -310,8 +312,10 @@ HRESULT SetupFiles::BuildFileLists() {
 
   core_program_files_.push_back(kPSFileNameUser);
   core_program_files_.push_back(kPSFileNameUser64);
+  core_program_files_.push_back(kPSFileNameUserArm64);
   core_program_files_.push_back(kPSFileNameMachine);
   core_program_files_.push_back(kPSFileNameMachine64);
+  core_program_files_.push_back(kPSFileNameMachineArm64);
 
   metainstaller_files_.clear();
   metainstaller_files_.push_back(kOmahaMetainstallerFileName);

--- a/omaha/setup/setup_files_unittest.cc
+++ b/omaha/setup/setup_files_unittest.cc
@@ -36,7 +36,7 @@ namespace {
 // TODO(omaha3): Update the numbers in the else block as we build more files.
 // Eventually use the original values in the if block.
 const int kNumberOfLanguageDlls = 55;
-const int kNumberOfCoreFiles = 10;
+const int kNumberOfCoreFiles = 14;
 const int kNumberOfMetainstallerFiles = 1;
 const int kNumberOfOptionalFiles = 2;
 const int kNumberOfInstalledRequiredFiles =

--- a/omaha/site_scons/site_tools/omaha_builders.py
+++ b/omaha/site_scons/site_tools/omaha_builders.py
@@ -367,47 +367,67 @@ def ConfigureEnvFor64Bit(env):
   Args:
     env: The environment.
   """
-  env.AppendUnique(ARFLAGS=['/MACHINE:x64'],
-                   LIBFLAGS=['/MACHINE:x64'],
-                   LINKFLAGS=['/MACHINE:x64'])
+  ConfigureEnvForNon32Bit(env, 'x64', '.obj64', '5.02', 'amd64')
+
+
+def ConfigureEnvForArm64Bit(env):
+  """Modifies the flags and compiler\library paths of an environment to
+     configure it to produce Arm64 binaries.
+
+  Args:
+    env: The environment.
+  """
+  ConfigureEnvForNon32Bit(env, 'arm64', '.objarm64', '6.02')
+  env.FilterOut(CPPDEFINES=['ARCH_CPU_X86_FAMILY'])
+  env.AppendUnique(CPPDEFINES=['ARCH_CPU_ARM_FAMILY', 'ARCH_CPU_ARM64'])
+
+
+def ConfigureEnvForNon32Bit(env, platform, objsuffix, subsystem,
+                            platform_legacy=None):
+  if platform_legacy is None:
+    platform_legacy = platform
+
+  env.AppendUnique(ARFLAGS=['/MACHINE:' + platform],
+                   LIBFLAGS=['/MACHINE:' + platform],
+                   LINKFLAGS=['/MACHINE:' + platform])
 
   platform_sdk_lib_dir = ('$WINDOWS_SDK_10_0_DIR/lib/' +
       '$WINDOWS_SDK_10_0_VERSION')
 
   lib_paths = {
-      omaha_version_utils.VC80: [ '$VC80_DIR/vc/lib/amd64',
-                                  '$ATLMFC_VC80_DIR/lib/amd64',
-                                  '$PLATFORM_SDK_VISTA_6_0_DIR/lib/x64' ],
-      omaha_version_utils.VC100: [ '$VC10_0_DIR/vc/lib/amd64',
-                                   '$ATLMFC_VC10_0_DIR/lib/amd64',
-                                   '$PLATFORM_SDK_VC10_0_DIR/lib/x64' ],
-      omaha_version_utils.VC120: [ '$VC12_0_DIR/vc/lib/amd64',
-                                   '$ATLMFC_VC12_0_DIR/lib/amd64',
-                                   '$WINDOWS_SDK_8_1_DIR/lib/winv6.3/um/x64' ],
-      omaha_version_utils.VC140: [ '$VC14_0_DIR/vc/lib/amd64',
-                                   '$ATLMFC_VC14_0_DIR/lib/amd64',
-                                   platform_sdk_lib_dir + '/um/x64',
-                                   platform_sdk_lib_dir + '/ucrt/x64',],
-      omaha_version_utils.VC150: [ '$VC15_0_DIR/lib/x64',
-                                   '$ATLMFC_VC15_0_DIR/lib/x64',
-                                   '$WINDOWS_SDK_10_0_LIB_DIR/um/x64',
-                                   '$WINDOWS_SDK_10_0_LIB_DIR/ucrt/x64',],
-      omaha_version_utils.VC160: [ '$VC16_0_DIR/lib/x64',
-                                   '$ATLMFC_VC16_0_DIR/lib/x64',
-                                   '$WINDOWS_SDK_10_0_LIB_DIR/um/x64',
-                                   '$WINDOWS_SDK_10_0_LIB_DIR/ucrt/x64',],
+      omaha_version_utils.VC80: [ '$VC80_DIR/vc/lib/' + platform_legacy,
+                                  '$ATLMFC_VC80_DIR/lib/' + platform_legacy,
+                                  '$PLATFORM_SDK_VISTA_6_0_DIR/lib' + platform ],
+      omaha_version_utils.VC100: [ '$VC10_0_DIR/vc/lib/' + platform_legacy,
+                                   '$ATLMFC_VC10_0_DIR/lib/' + platform_legacy,
+                                   '$PLATFORM_SDK_VC10_0_DIR/lib' + platform ],
+      omaha_version_utils.VC120: [ '$VC12_0_DIR/vc/lib/' + platform_legacy,
+                                   '$ATLMFC_VC12_0_DIR/lib/' + platform_legacy,
+                                   '$WINDOWS_SDK_8_1_DIR/lib/winv6.3/um' + platform ],
+      omaha_version_utils.VC140: [ '$VC14_0_DIR/vc/lib/' + platform_legacy,
+                                   '$ATLMFC_VC14_0_DIR/lib/' + platform_legacy,
+                                   platform_sdk_lib_dir + '/um' + platform,
+                                   platform_sdk_lib_dir + '/ucrt' + platform,],
+      omaha_version_utils.VC150: [ '$VC15_0_DIR/lib/' + platform,
+                                   '$ATLMFC_VC15_0_DIR/lib/' + platform,
+                                   '$WINDOWS_SDK_10_0_LIB_DIR/um/' + platform,
+                                   '$WINDOWS_SDK_10_0_LIB_DIR/ucrt/' + platform,],
+      omaha_version_utils.VC160: [ '$VC16_0_DIR/lib/' + platform,
+                                   '$ATLMFC_VC16_0_DIR/lib/' + platform,
+                                   '$WINDOWS_SDK_10_0_LIB_DIR/um/' + platform,
+                                   '$WINDOWS_SDK_10_0_LIB_DIR/ucrt/' + platform,],
       }[env['msc_ver']]
 
   env.Prepend(LIBPATH=lib_paths)
 
   # Override the build tools to be the x86-64 version.
   env.PrependENVPath('PATH', env.Dir(
-      {omaha_version_utils.VC80  : '$VC80_DIR/vc/bin/x86_amd64',
-       omaha_version_utils.VC100 : '$VC10_0_DIR/vc/bin/x86_amd64',
-       omaha_version_utils.VC120 : '$VC12_0_DIR/vc/bin/x86_amd64',
-       omaha_version_utils.VC140 : '$VC14_0_DIR/vc/bin/x86_amd64',
-       omaha_version_utils.VC150 : '$VC15_0_DIR/bin/HostX64/x64',
-       omaha_version_utils.VC160 : '$VC16_0_DIR/bin/HostX64/x64'}
+      {omaha_version_utils.VC80  : '$VC80_DIR/vc/bin/x86_' + platform_legacy,
+       omaha_version_utils.VC100 : '$VC10_0_DIR/vc/bin/x86_' + platform_legacy,
+       omaha_version_utils.VC120 : '$VC12_0_DIR/vc/bin/x86_' + platform_legacy,
+       omaha_version_utils.VC140 : '$VC14_0_DIR/vc/bin/x86_' + platform_legacy,
+       omaha_version_utils.VC150 : '$VC15_0_DIR/bin/HostX64/' + platform,
+       omaha_version_utils.VC160 : '$VC16_0_DIR/bin/HostX64/' + platform}
       [env['msc_ver']]))
 
   # Filter x86 options that are not supported or conflict with x86-x64 options.
@@ -421,21 +441,22 @@ def ConfigureEnvFor64Bit(env):
 
   # x86-64 has a different minimum requirements for the Windows subsystem.
   env.FilterOut(LINKFLAGS=['/SUBSYSTEM:WINDOWS,5.01'])
-  env.AppendUnique(LINKFLAGS=['/SUBSYSTEM:WINDOWS,5.02'])
+  env.AppendUnique(LINKFLAGS=['/SUBSYSTEM:WINDOWS,' + subsystem])
 
   # Modify output filenames such that .obj becomes .obj64.  (We can't modify
   # LIBPREFIX in the same way, unfortunately, because the 64-bit compilers
   # supply the base libraries as .lib.)
-  env['OBJSUFFIX'] = '.obj64'
+  env['OBJSUFFIX'] = objsuffix
 
   # Set the bit to denote that this environment generates 64-bit targets.
   # (This is used by several .scons files to adjust target names.)
-  env.SetBits('x64')
+  env.SetBits(platform)
 
   # If this is a coverage build, skip instrumentation for 64-bit binaries,
   # as VSInstr doesn't currently support those.
   if env.IsCoverageBuild():
     env['INSTALL'] = env['PRECOVERAGE_INSTALL']
+
 
 def CloneAndMake64Bit(env):
   """Clones the supplied environment and calls ConfigureEnvFor64Bit()
@@ -452,6 +473,12 @@ def CloneAndMake64Bit(env):
   return env64
 
 
+def CloneAndMakeArm64Bit(env):
+  env_arm64 = env.Clone()
+  ConfigureEnvForArm64Bit(env_arm64)
+  return env_arm64
+
+
 def GetMultiarchLibName(env, lib_name):
   """Decorates the lib name based on whether or not the environment is intended
   to produce 64-bit binaries.
@@ -463,7 +490,13 @@ def GetMultiarchLibName(env, lib_name):
   Returns:
     The appropriate library name.
   """
-  filename = (lib_name, '%s_64' % lib_name)[env.Bit('x64')]
+  if env.Bit('x64'):
+    suffix = '_64'
+  elif env.Bit('arm64'):
+    suffix = '_arm64'
+  else:
+    suffix = ''
+  filename = lib_name + suffix
   return '$LIB_DIR/' + filename + '.lib'
 
 
@@ -492,7 +525,14 @@ def ComponentStaticLibraryMultiarch(env, lib_name, *args, **kwargs):
   nodes64 = ComponentStaticLibrary(CloneAndMake64Bit(env),
                                    '%s_64' % lib_name,
                                    *args64, **kwargs64)
-  return nodes32 + nodes64
+  # As above, make a copy of the input arg lists because ComponentStaticLibrary
+  # modifies them.
+  args_arm64 = [copy(arg) for arg in args]
+  kwargs_arm64 = deepcopy(kwargs)
+  nodesarm64 = ComponentStaticLibrary(CloneAndMakeArm64Bit(env),
+                                      '%s_arm64' % lib_name,
+                                      *args_arm64, **kwargs64)
+  return nodes32 + nodes64 + nodesarm64
 
 
 # os.path.relpath is not available in Python 2.4, so make our own.
@@ -577,6 +617,7 @@ def generate(env):  # pylint: disable=C6409
   env.AddMethod(CopyFileToDirectory)
   env.AddMethod(ConfigureEnvFor64Bit)
   env.AddMethod(CloneAndMake64Bit)
+  env.AddMethod(CloneAndMakeArm64Bit)
   env.AddMethod(GetMultiarchLibName)
   env.AddMethod(ComponentStaticLibraryMultiarch)
   env.AddMethod(CompileProtoBuf)

--- a/omaha/third_party/chrome/files/src/build/build_config.h
+++ b/omaha/third_party/chrome/files/src/build/build_config.h
@@ -99,6 +99,11 @@
 #define ARCH_CPU_32_BITS 1
 #define ARCH_CPU_LITTLE_ENDIAN 1
 #define WCHAR_T_IS_UNSIGNED 1
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#define ARCH_CPU_ARM_FAMILY 1
+#define ARCH_CPU_ARM64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
 #elif defined(__pnacl__)
 #define ARCH_CPU_32_BITS 1
 #else


### PR DESCRIPTION
The same tests fail as before. On x64 Windows 10:

 * TimeTest.RFC822TimeParsing
 * OmahaCustomizationTest.IsInternalUser
 * PingTest.BuildOmahaPing
 * PingTest.SendInProcess
 * PingTest.PersistAndSendPersistedPings
 * WebServicesClientTest.Send
 * WebServicesClientTest.SendForcingHttps
 * WebServicesClientTest.SendWithCustomHeader
 * WebServicesClientTest.SendStringWithCustomHeader
 * InstallManagerInstallAppMachineTest.InstallApp_MsiInstallerSucceeds
 * InstallManagerInstallAppMachineTest.InstallApp_MsiInstallerWithArgumentSucceeds
 * InstallerWrapperMachineTest.InstallApp_MsiInstallerSucceeds
 * InstallerWrapperMachineTest.InstallApp_MsiInstallerWithArgumentSucceeds
 * WorkerWithTwoAppsTest.CheckForUpdateAsync_Large
 * WorkerWithTwoAppsTest.DownloadAsyncThenDownloadAndInstallAsync_Large
 * CupEcdsaRequestTest.PostSimpleRequest
 * CupEcdsaRequestTest.PostSimpleRequestHttps
 * NetworkRequestTest.MultipleRequests
 * GoogleUpdateRecoveryTest.FixGoogleUpdate_FileReturned_Machine
 * GoogleUpdateRecoveryTest.FixGoogleUpdate_FileReturned_User
 * GoogleUpdateRecoveryTest.FixGoogleUpdate_FileCollision
 * GoogleUpdateRecoveryTest.VerifyFileSignature_SignedValid
 * GoogleUpdateRecoveryTest.ProductionServerResponseTest
 * SetupUserTest.TerminateCoreProcesses_BothTypesRunningAndSimilarArgsProcess
 * SetupMachineTest.StopGoogleUpdateAndWait_ProcessesDoNotStop
 * SetupMachineTest.StopGoogleUpdateAndWait_UserHandoffWorkerRunningAsSystem
 * SetupMachineTest.StopGoogleUpdateAndWait_UserLegacyInstallGoogleUpdateWorkerRunningAsSystem
 * SetupMachineTest.TerminateCoreProcesses_BothTypesRunningAndSimilarArgsProcess
 * UnitTestHelpersTest.ClearGroupPolicies
 * IsForeground/WebServicesClientTest.SendUsingCup/0, where GetParam() = false
 * IsForeground/WebServicesClientTest.SendUsingCup/1, where GetParam() = true
 * IsForeground/WebServicesClientTest.SendString/0, where GetParam() = false
 * IsForeground/WebServicesClientTest.SendString/1, where GetParam() = true

Additionally, on Arm64 Windows 11, the following tests failed before and also fail now:

 * UserInfoTest.GetProcessUserSid
 * VistaUtilTest.IsUACOn
 * VistaUtilTest.IsElevatedWithUACOn
 * GoopdateUtilsTest.ResetUserId_MACHashes
 * GoopdateUtilsTest.ResetUserIdIfMacMismatch
 * NetworkConfigTest.GetProxyForUrlLocal