### PR TITLE
Support Arm64 online installer

### DIFF
--- a/omaha/VERSION
+++ b/omaha/VERSION
@@ -5,4 +5,4 @@
 version_major = 1    # 1-65535
 version_minor = 3    # 0-65535
 version_build = 361   # 1-65535
-version_patch = 137    # 0-65535
+version_patch = 143    # 0-65535

--- a/omaha/base/system_info.cc
+++ b/omaha/base/system_info.cc
@@ -14,6 +14,11 @@
 // ========================================================================
 
 #include "omaha/base/system_info.h"
+
+#include <windows.h>
+
+#include <map>
+
 #include "base/basictypes.h"
 #include "omaha/base/debug.h"
 #include "omaha/base/error.h"
@@ -25,6 +30,102 @@
 #include "omaha/base/wmi_query.h"
 
 namespace omaha {
+
+const TCHAR* const kArchAmd64 = _T("x64");
+const TCHAR* const kArchIntel = _T("x86");
+const TCHAR* const kArchArm64 = _T("arm64");
+const TCHAR* const kArchUnknown = _T("unknown");
+
+namespace {
+// Returns the processor architecture as returned by `::GetNativeSystemInfo()`
+// to detect the processor architecture of the installed operating system. See
+// http://msdn.microsoft.com/en-us/library/ms724340.aspx.
+//
+// If the function is called from an x86 or x64 application running on a 64-bit
+// system that does not have an Intel64 or x64 processor (such as ARM64), it
+// will return information as if the system is x86 only if x86 emulation is
+// supported (or x64 if x64 emulation is also supported).
+DWORD GetProcessorArchitecture() {
+  static DWORD processor_architecture_cached(PROCESSOR_ARCHITECTURE_UNKNOWN);
+
+  if (processor_architecture_cached == PROCESSOR_ARCHITECTURE_UNKNOWN) {
+    typedef void(WINAPI * GetSystemInfoFunc)(LPSYSTEM_INFO);
+
+    HMODULE handle = ::GetModuleHandle(_T("kernel32"));
+    ASSERT1(handle);
+    GetSystemInfoFunc get_native_system_info =
+        reinterpret_cast<GetSystemInfoFunc>(
+            ::GetProcAddress(handle, "GetNativeSystemInfo"));
+
+    if (get_native_system_info != NULL) {
+      SYSTEM_INFO sys_info = {0};
+
+      get_native_system_info(&sys_info);
+
+      processor_architecture_cached = sys_info.wProcessorArchitecture;
+    } else {
+      // If we couldn't get the _native_ system info, then we must be on OS
+      // earlier than XP, so can't be 64-bit anyway. Assume Intel.
+      processor_architecture_cached = PROCESSOR_ARCHITECTURE_INTEL;
+    }
+  }
+
+  return processor_architecture_cached;
+}
+
+// Returns a string representation of the processor architecture if one exists,
+// or an empty string if there is no match.
+CString GetProcessorArchitectureString() {
+  switch (GetProcessorArchitecture()) {
+    case PROCESSOR_ARCHITECTURE_INTEL:
+      return kArchIntel;
+
+    case PROCESSOR_ARCHITECTURE_AMD64:
+      return kArchAmd64;
+
+    default:
+      ASSERT1(false);
+      return kArchUnknown;
+  }
+}
+
+// Returns the native architecture if the current process is running under
+// WOW64 and `::IsWow64Process2()` is available. Otherwise returns
+// `IMAGE_FILE_MACHINE_UNKNOWN`.
+USHORT GetNativeArchitecture() {
+  typedef BOOL(WINAPI * IsWow64Process2Func)(HANDLE, USHORT*, USHORT*);
+  const IsWow64Process2Func is_wow64_process2 =
+      reinterpret_cast<IsWow64Process2Func>(::GetProcAddress(
+          ::GetModuleHandle(_T("kernel32.dll")), "IsWow64Process2"));
+  if (!is_wow64_process2) {
+    return IMAGE_FILE_MACHINE_UNKNOWN;
+  }
+
+  USHORT process_machine = 0;
+  USHORT native_architecture = IMAGE_FILE_MACHINE_UNKNOWN;
+  return is_wow64_process2(::GetCurrentProcess(), &process_machine,
+                           &native_architecture)
+             ? native_architecture
+             : IMAGE_FILE_MACHINE_UNKNOWN;
+}
+
+// Returns a string representation of the native architecture if one exists,
+// or an empty string if there is no match.
+CString GetNativeArchitectureString() {
+  const std::map<int, CString> kNativeArchitectureImagesToStrings = {
+      {IMAGE_FILE_MACHINE_I386, kArchIntel},
+      {IMAGE_FILE_MACHINE_AMD64, kArchAmd64},
+      {IMAGE_FILE_MACHINE_ARM64, kArchArm64},
+  };
+
+  const auto native_arch =
+      kNativeArchitectureImagesToStrings.find(GetNativeArchitecture());
+  return native_arch != kNativeArchitectureImagesToStrings.end()
+             ? native_arch->second
+             : CString(_T(""));
+}
+
+}  // namespace
 
 bool SystemInfo::IsRunningOnXPSP2OrLater() {
   return ::IsWindowsXPSP2OrGreater();
@@ -111,33 +212,46 @@ bool SystemInfo::GetSystemVersion(int* major_version,
   return true;
 }
 
-DWORD SystemInfo::GetProcessorArchitecture() {
-  static DWORD processor_architecture_cached(PROCESSOR_ARCHITECTURE_UNKNOWN);
+CString SystemInfo::GetArchitecture() {
+  const CString native_arch = GetNativeArchitectureString();
+  return !native_arch.IsEmpty() ? native_arch
+                                : GetProcessorArchitectureString();
+}
 
-  if (processor_architecture_cached == PROCESSOR_ARCHITECTURE_UNKNOWN) {
-    typedef void (WINAPI * GetSystemInfoFunc)(LPSYSTEM_INFO);
+bool SystemInfo::IsArchitectureSupported(const CString& arch) {
+  if (arch.IsEmpty()) {
+    return true;
+  }
 
-    HMODULE handle = ::GetModuleHandle(_T("kernel32"));
-    ASSERT1(handle);
-    GetSystemInfoFunc get_native_system_info =
-        reinterpret_cast<GetSystemInfoFunc>(::GetProcAddress(
-                                                handle,
-                                                "GetNativeSystemInfo"));
+  const CString current_arch = GetArchitecture().MakeLower();
+  if (arch == current_arch) {
+    return true;
+  }
 
-    if (get_native_system_info != NULL) {
-      SYSTEM_INFO sys_info = {0};
+  typedef HRESULT(WINAPI * IsWow64GuestMachineSupportedFunc)(USHORT, BOOL*);
+  const IsWow64GuestMachineSupportedFunc is_wow64_guest_machine_supported =
+      reinterpret_cast<IsWow64GuestMachineSupportedFunc>(
+          ::GetProcAddress(::GetModuleHandle(_T("kernel32.dll")),
+                           "IsWow64GuestMachineSupported"));
 
-      get_native_system_info(&sys_info);
+  if (is_wow64_guest_machine_supported) {
+    const std::map<CString, int> kNativeArchitectureStringsToImages = {
+        {kArchIntel, IMAGE_FILE_MACHINE_I386},
+        {kArchAmd64, IMAGE_FILE_MACHINE_AMD64},
+        {kArchArm64, IMAGE_FILE_MACHINE_ARM64},
+    };
 
-      processor_architecture_cached = sys_info.wProcessorArchitecture;
-    } else {
-      // If we couldn't get the _native_ system info, then we must be on OS
-      // earlier than XP, so can't be 64-bit anyway. Assume Intel.
-      processor_architecture_cached = PROCESSOR_ARCHITECTURE_INTEL;
+    const auto image = kNativeArchitectureStringsToImages.find(arch);
+    if (image != kNativeArchitectureStringsToImages.end()) {
+      BOOL is_machine_supported = false;
+      if (SUCCEEDED(is_wow64_guest_machine_supported(
+              static_cast<USHORT>(image->second), &is_machine_supported))) {
+        return is_machine_supported;
+      }
     }
   }
 
-  return processor_architecture_cached;
+  return arch == kArchIntel;
 }
 
 bool SystemInfo::Is64BitWindows() {
@@ -237,8 +351,7 @@ VersionType SystemInfo::GetOSVersionType() {
   } else if (version_info.dwMajorVersion == 5 &&
              version_info.dwMinorVersion == 2) {
     if (version_info.wProductType == VER_NT_WORKSTATION &&
-        SystemInfo::GetProcessorArchitecture() ==
-        PROCESSOR_ARCHITECTURE_AMD64) {
+        SystemInfo::GetArchitecture() == kArchAmd64) {
       return SUITE_PROFESSIONAL;
     } else if (version_info.wSuiteMask & VER_SUITE_WH_SERVER) {
       return SUITE_HOME;

--- a/omaha/base/system_info.h
+++ b/omaha/base/system_info.h
@@ -27,6 +27,11 @@
 
 namespace omaha {
 
+extern const TCHAR* const kArchAmd64;
+extern const TCHAR* const kArchIntel;
+extern const TCHAR* const kArchArm64;
+extern const TCHAR* const kArchUnknown;
+
 enum VersionType {
   SUITE_HOME = 0,
   SUITE_PROFESSIONAL,
@@ -78,12 +83,20 @@ class SystemInfo {
                                int* service_pack_major,
                                int* service_pack_minor);
 
-  // Returns the processor architecture. We use wProcessorArchitecture in
-  // SYSTEM_INFO returned by ::GetNativeSystemInfo() to detect the processor
-  // architecture of the installed operating system. Note the "Native" in the
-  // function name - this is important. See
-  // http://msdn.microsoft.com/en-us/library/ms724340.aspx.
-  static DWORD GetProcessorArchitecture();
+  // Returns a string representation of the processor architecture, or an empty
+  // string if the processor architecture is unknown. Uses `::IsWow64Process2()`
+  // if available (more accurate). If not, falls back on
+  // `::GetNativeSystemInfo()` (less accurate, but available on most systems).
+  static CString GetArchitecture();
+
+  // Returns `true` if:
+  //* `arch` is empty, or
+  // * `arch` matches the currrent architecture, or
+  // * `arch` is supported on the machine, as determined by
+  // `::IsWow64GuestMachineSupported()`.
+  //   * If `::IsWow64GuestMachineSupported()` is not available, returns `true`
+  //     if `arch` is x86.
+  static bool IsArchitectureSupported(const CString& arch);
 
   // Returns whether this is a 64-bit Windows system.
   static bool Is64BitWindows();

--- a/omaha/base/system_info_unittest.cc
+++ b/omaha/base/system_info_unittest.cc
@@ -35,22 +35,25 @@ TEST(SystemInfoTest, GetSystemVersion) {
 }
 
 TEST(SystemInfoTest, Is64BitWindows) {
-  DWORD arch(SystemInfo::GetProcessorArchitecture());
+  const CString arch = SystemInfo::GetArchitecture();
 
-  if (arch == PROCESSOR_ARCHITECTURE_INTEL) {
+  if (arch == kArchIntel) {
     EXPECT_FALSE(SystemInfo::Is64BitWindows());
   } else {
     EXPECT_TRUE(SystemInfo::Is64BitWindows());
   }
 }
 
-TEST(SystemInfoTest, GetProcessorArchitecture) {
-  DWORD arch(SystemInfo::GetProcessorArchitecture());
+TEST(SystemInfoTest, GetArchitecture) {
+  const CString arch = SystemInfo::GetArchitecture();
 
-  // TODO(omaha3): Maybe we could look for the presence of a wow6432 key in the
-  // registry to detect.
-  EXPECT_TRUE(arch == PROCESSOR_ARCHITECTURE_INTEL ||
-              arch == PROCESSOR_ARCHITECTURE_AMD64);
+  EXPECT_TRUE(arch == kArchIntel || arch == kArchAmd64) << arch;
+}
+
+TEST(SystemInfoTest, IsArchitectureSupported) {
+  const CString arch = SystemInfo::GetArchitecture();
+
+  EXPECT_TRUE(SystemInfo::IsArchitectureSupported(arch)) << arch;
 }
 
 TEST(SystemInfoTest, CompareOSVersions_SameAsCurrent) {

--- a/omaha/common/protocol_definition.h
+++ b/omaha/common/protocol_definition.h
@@ -68,7 +68,7 @@ struct OS {
   CString platform;       // "win".
   CString version;        // major.minor.
   CString service_pack;
-  CString arch;           // "x86", "x64", or "unknown".
+  CString arch;  // "x86", "x64", "ARM64", etc, or "unknown".
 };
 
 struct UpdateCheck {
@@ -300,7 +300,19 @@ struct DayStart {
 
 struct SystemRequirements {
   CString platform;        // "win".
-  CString arch;            // "x86", "x64", or "unknown".
+
+  // Expected host processor architecture that the app is compatible with.
+  // `arch` can be a single entry, or multiple entries separated with `,`.
+  // Entries prefixed with a `-` (negative entries) indicate non-compatible
+  // hosts.
+  //
+  // Examples:
+  // * `arch` == "x86".
+  // * `arch` == "x64".
+  // * `arch` == "x86,x64,-arm64": the app will fail installation if the
+  // underlying host is arm64.
+  CString arch;
+
   CString min_os_version;  // major.minor.
 };
 

--- a/omaha/common/update_request.cc
+++ b/omaha/common/update_request.cc
@@ -106,8 +106,7 @@ UpdateRequest* UpdateRequest::Create(bool is_machine,
   request.os.platform = kPlatformWin;
   VERIFY_SUCCEEDED(goopdate_utils::GetOSInfo(&request.os.version,
                                               &request.os.service_pack));
-  request.os.arch = xml::ConvertProcessorArchitectureToString(
-      SystemInfo::GetProcessorArchitecture());
+  request.os.arch = SystemInfo::GetArchitecture();
 
   return update_request.release();
 }

--- a/omaha/common/xml_const.cc
+++ b/omaha/common/xml_const.cc
@@ -156,10 +156,6 @@ const TCHAR* const kAppDefinedPrefix = _T("_");
 
 namespace value {
 
-const TCHAR* const kArchAmd64 = _T("x64");
-const TCHAR* const kArchArm64 = _T("arm64");
-const TCHAR* const kArchIntel = _T("x86");
-const TCHAR* const kArchUnknown = _T("unknown");
 const TCHAR* const kBits = _T("bits");
 const TCHAR* const kCacheable = _T("cacheable");
 const TCHAR* const kClientRegulated = _T("cr");

--- a/omaha/common/xml_const.h
+++ b/omaha/common/xml_const.h
@@ -156,10 +156,6 @@ extern const TCHAR* const kAppDefinedPrefix;
 
 namespace value {
 
-extern const TCHAR* const kArchAmd64;
-extern const TCHAR* const kArchArm64;
-extern const TCHAR* const kArchIntel;
-extern const TCHAR* const kArchUnknown;
 extern const TCHAR* const kBits;
 extern const TCHAR* const kCacheable;
 extern const TCHAR* const kClientRegulated;

--- a/omaha/common/xml_parser.cc
+++ b/omaha/common/xml_parser.cc
@@ -146,23 +146,6 @@ HRESULT VerifyProtocolCompatibility(const CString& actual_version,
 
 }  // namespace
 
-CString ConvertProcessorArchitectureToString(DWORD arch) {
-  switch (arch) {
-    case PROCESSOR_ARCHITECTURE_INTEL:
-      return xml::value::kArchIntel;
-
-    case PROCESSOR_ARCHITECTURE_AMD64:
-      return xml::value::kArchAmd64;
-
-    case PROCESSOR_ARCHITECTURE_ARM64:
-      return xml::value::kArchArm64;
-
-    default:
-      ASSERT1(false);
-      return xml::value::kArchUnknown;
-  }
-}
-
 // The ElementHandler classes should also be in an anonymous namespace but
 // the base class cannot be because it is used in the header file.
 

--- a/omaha/common/xml_parser.h
+++ b/omaha/common/xml_parser.h
@@ -38,8 +38,6 @@ namespace xml {
 
 class ElementHandler;
 
-CString ConvertProcessorArchitectureToString(DWORD processor_architecture);
-
 // Public static methods instantiate a temporary instance of this class, which
 // then parses the specified document. This avoids reusing instances of the
 // parser and dealing with stale and dirty data.

--- a/omaha/common/xml_parser_unittest.cc
+++ b/omaha/common/xml_parser_unittest.cc
@@ -248,8 +248,53 @@ TEST_F(XmlParserTest, Parse) {
   // Array of two request strings that are almost same except the second one
   // contains some unsupported elements that we expect to be ignored.
   CStringA buffer_strings[] = {
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><response protocol=\"3.0\"><systemrequirements platform=\"win\" arch=\"x86\" min_os_version=\"6.0\"/><daystart elapsed_seconds=\"8400\" elapsed_days=\"3255\" /><app appid=\"{8A69D345-D564-463C-AFF1-A69D9E530F96}\" status=\"ok\" cohort=\"Cohort1\" cohorthint=\"Hint1\" cohortname=\"Name1\" experiments=\"url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT\"><updatecheck status=\"ok\"><urls><url codebase=\"http://cache.pack.google.com/edgedl/chrome/install/172.37/\"/></urls><manifest version=\"2.0.172.37\"><packages><package hash_sha256=\"d5e06b4436c5e33f2de88298b890f47815fc657b63b3050d2217c55a5d0730b0\" hash=\"NT/6ilbSjWgbVqHZ0rT1vTg1coE=\" name=\"chrome_installer.exe\" required=\"true\" size=\"9614320\"/></packages><actions><action arguments=\"--do-not-launch-chrome\" event=\"install\" needsadmin=\"false\" run=\"chrome_installer.exe\"/><action event=\"postinstall\" onsuccess=\"exitsilentlyonlaunchcmd\"/></actions></manifest></updatecheck><data index=\"verboselogging\" name=\"install\" status=\"ok\">{\n \"distribution\": {\n   \"verbose_logging\": true\n }\n}\n</data><data name=\"untrusted\" status=\"ok\"/><ping status=\"ok\"/></app></response>",  // NOLINT
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><response protocol=\"3.0\" ExtraUnsupportedAttribute=\"123\"><daystart elapsed_seconds=\"8400\" elapsed_days=\"3255\" /><UnsupportedElement1 UnsupportedAttribute1=\"some value\" /><app appid=\"{8A69D345-D564-463C-AFF1-A69D9E530F96}\" status=\"ok\" cohort=\"Cohort1\" cohorthint=\"Hint1\" cohortname=\"Name1\" experiments=\"url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT\"><updatecheck status=\"ok\"><urls><url codebase=\"http://cache.pack.google.com/edgedl/chrome/install/172.37/\"/></urls><manifest version=\"2.0.172.37\"><packages><package hash_sha256=\"d5e06b4436c5e33f2de88298b890f47815fc657b63b3050d2217c55a5d0730b0\" hash=\"NT/6ilbSjWgbVqHZ0rT1vTg1coE=\" name=\"chrome_installer.exe\" required=\"true\" size=\"9614320\"/></packages><actions><action arguments=\"--do-not-launch-chrome\" event=\"install\" needsadmin=\"false\" run=\"chrome_installer.exe\"/><action event=\"postinstall\" onsuccess=\"exitsilentlyonlaunchcmd\"/></actions></manifest></updatecheck><data index=\"verboselogging\" name=\"install\" status=\"ok\">{\n \"distribution\": {\n   \"verbose_logging\": true\n }\n}\n</data><data name=\"untrusted\" status=\"ok\"/><ping status=\"ok\"/></app><UnsupportedElement2 UnsupportedAttribute2=\"Unsupported value\" >Some strings inside an unsupported element, should be ignored.<ping status=\"ok\"/></UnsupportedElement2></response>",  // NOLINT
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><response "
+      "protocol=\"3.0\"><systemrequirements platform=\"win\" "
+      "arch=\"x86,-arm64\" min_os_version=\"6.0\"/><daystart "
+      "elapsed_seconds=\"8400\" elapsed_days=\"3255\" /><app "
+      "appid=\"{8A69D345-D564-463C-AFF1-A69D9E530F96}\" status=\"ok\" "
+      "cohort=\"Cohort1\" cohorthint=\"Hint1\" cohortname=\"Name1\" "
+      "experiments=\"url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT\"><updatecheck "
+      "status=\"ok\"><urls><url "
+      "codebase=\"http://cache.pack.google.com/edgedl/chrome/install/172.37/\"/"
+      "></urls><manifest version=\"2.0.172.37\"><packages><package "
+      "hash_sha256="
+      "\"d5e06b4436c5e33f2de88298b890f47815fc657b63b3050d2217c55a5d0730b0\" "
+      "hash=\"NT/6ilbSjWgbVqHZ0rT1vTg1coE=\" name=\"chrome_installer.exe\" "
+      "required=\"true\" size=\"9614320\"/></packages><actions><action "
+      "arguments=\"--do-not-launch-chrome\" event=\"install\" "
+      "needsadmin=\"false\" run=\"chrome_installer.exe\"/><action "
+      "event=\"postinstall\" "
+      "onsuccess=\"exitsilentlyonlaunchcmd\"/></actions></manifest></"
+      "updatecheck><data index=\"verboselogging\" name=\"install\" "
+      "status=\"ok\">{\n \"distribution\": {\n   \"verbose_logging\": true\n "
+      "}\n}\n</data><data name=\"untrusted\" status=\"ok\"/><ping "
+      "status=\"ok\"/></app></response>",  // NOLINT
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><response protocol=\"3.0\" "
+      "ExtraUnsupportedAttribute=\"123\"><daystart elapsed_seconds=\"8400\" "
+      "elapsed_days=\"3255\" /><UnsupportedElement1 "
+      "UnsupportedAttribute1=\"some value\" /><app "
+      "appid=\"{8A69D345-D564-463C-AFF1-A69D9E530F96}\" status=\"ok\" "
+      "cohort=\"Cohort1\" cohorthint=\"Hint1\" cohortname=\"Name1\" "
+      "experiments=\"url_exp_2=a|Fri, 14 Aug 2015 16:13:03 GMT\"><updatecheck "
+      "status=\"ok\"><urls><url "
+      "codebase=\"http://cache.pack.google.com/edgedl/chrome/install/172.37/\"/"
+      "></urls><manifest version=\"2.0.172.37\"><packages><package "
+      "hash_sha256="
+      "\"d5e06b4436c5e33f2de88298b890f47815fc657b63b3050d2217c55a5d0730b0\" "
+      "hash=\"NT/6ilbSjWgbVqHZ0rT1vTg1coE=\" name=\"chrome_installer.exe\" "
+      "required=\"true\" size=\"9614320\"/></packages><actions><action "
+      "arguments=\"--do-not-launch-chrome\" event=\"install\" "
+      "needsadmin=\"false\" run=\"chrome_installer.exe\"/><action "
+      "event=\"postinstall\" "
+      "onsuccess=\"exitsilentlyonlaunchcmd\"/></actions></manifest></"
+      "updatecheck><data index=\"verboselogging\" name=\"install\" "
+      "status=\"ok\">{\n \"distribution\": {\n   \"verbose_logging\": true\n "
+      "}\n}\n</data><data name=\"untrusted\" status=\"ok\"/><ping "
+      "status=\"ok\"/></app><UnsupportedElement2 "
+      "UnsupportedAttribute2=\"Unsupported value\" >Some strings inside an "
+      "unsupported element, should be ignored.<ping "
+      "status=\"ok\"/></UnsupportedElement2></response>",
   };
 
   for (int i = 0; i < arraysize(buffer_strings); i++) {
@@ -327,7 +372,7 @@ TEST_F(XmlParserTest, Parse) {
               update_response_utils::ValidateUntrustedData(app.data));
 
     EXPECT_STREQ(i == 0 ? _T("win") : _T(""), xml_response.sys_req.platform);
-    EXPECT_STREQ(i == 0 ? _T("x86") : _T(""), xml_response.sys_req.arch);
+    EXPECT_STREQ(i == 0 ? _T("x86,-arm64") : _T(""), xml_response.sys_req.arch);
     EXPECT_STREQ(i == 0 ? _T("6.0") : _T(""),
                  xml_response.sys_req.min_os_version);
   }

--- a/omaha/goopdate/dm_client.cc
+++ b/omaha/goopdate/dm_client.cc
@@ -390,7 +390,7 @@ CString GetAgent() {
 }
 
 CString GetPlatform() {
-  const DWORD architecture = SystemInfo::GetProcessorArchitecture();
+  const CString architecture = SystemInfo::GetArchitecture();
 
   int major_version = 0;
   int minor_version = 0;
@@ -404,13 +404,7 @@ CString GetPlatform() {
 
   CString platform;
   SafeCStringFormat(&platform, _T("Windows NT|%s|%d.%d.0"),
-                    architecture == PROCESSOR_ARCHITECTURE_AMD64 ?
-                        _T("x86_64") :
-                        (architecture == PROCESSOR_ARCHITECTURE_INTEL ?
-                             _T("x86") :
-                             architecture == PROCESSOR_ARCHITECTURE_ARM64 ?
-                                  _T("arm64") :
-                                  _T("")),
+                    architecture == kArchAmd64 ? _T("x86_64") : architecture,
                     major_version, minor_version);
   return platform;
 }

--- a/omaha/goopdate/update_response_utils.cc
+++ b/omaha/goopdate/update_response_utils.cc
@@ -18,13 +18,14 @@
 #include <algorithm>
 #include <regex>
 #include <string>
+#include <vector>
 
 #include "omaha/base/debug.h"
 #include "omaha/base/error.h"
 #include "omaha/base/logging.h"
 #include "omaha/base/system_info.h"
-#include "omaha/common/lang.h"
 #include "omaha/common/experiment_labels.h"
+#include "omaha/common/lang.h"
 #include "omaha/common/xml_const.h"
 #include "omaha/common/xml_parser.h"
 #include "omaha/goopdate/model.h"
@@ -58,17 +59,59 @@ bool IsPlatformCompatible(const CString& platform) {
   return platform.IsEmpty() || !platform.CompareNoCase(kPlatformWin);
 }
 
-bool IsArchCompatible(const CString& arch) {
-  const CString current_arch(xml::ConvertProcessorArchitectureToString(
-                                 SystemInfo::GetProcessorArchitecture()));
-  return arch.IsEmpty() ||
-         !arch.CompareNoCase(current_arch) ||
-         (arch == xml::value::kArchIntel &&
-         current_arch == xml::value::kArchAmd64) ||
-         (arch == xml::value::kArchIntel &&
-         current_arch == xml::value::kArchArm64) ||
-         (arch == xml::value::kArchAmd64 &&
-         current_arch == xml::value::kArchArm64);;
+// Checks if the current architecture is compatible with the entries in
+// `arch_list`. `arch_list` can be a single entry, or multiple entries separated
+// with `,`. Entries prefixed with `-` (negative entries) indicate
+// non-compatible hosts. Non-prefixed entries indicate compatible guests.
+//
+// Returns `true` if:
+// * `arch_list` is empty, or
+// * none of the negative entries within `arch_list` match the current host
+//   architecture exactly, and there are no non-negative entries, or
+// * one of the non-negative entries within `arch_list` matches the current
+//   architecture, or is compatible with the current architecture (i.e., it is a
+//   compatible guest for the current host) as determined by
+//   `::IsWow64GuestMachineSupported()`.
+//   * If `::IsWow64GuestMachineSupported()` is not available, returns `true`
+//     if `arch` is x86.
+//
+// Examples:
+// * `arch_list` == "x86": returns `true` if run on all systems, because Omaha3
+//   is x86, and is running the logic to determine compatibility).
+// * `arch_list` == "x64": returns `true` if run on x64 or many arm64 systems.
+// * `arch_list` == "x86,x64,-arm64": returns `false` if the underlying host is
+// arm64.
+// * `arch_list` == "-arm64": returns `false` if the underlying host is arm64.
+bool IsArchCompatible(const CString& arch_list) {
+  std::vector<CString> architectures;
+  int pos = 0;
+  do {
+    const CString arch = arch_list.Tokenize(_T(","), pos).Trim().MakeLower();
+    if (!arch.IsEmpty()) {
+      architectures.push_back(arch);
+    }
+  } while (pos != -1);
+
+  if (architectures.empty()) {
+    return true;
+  }
+
+  std::sort(architectures.begin(), architectures.end());
+  if (std::find(architectures.begin(), architectures.end(),
+                _T('-') + SystemInfo::GetArchitecture().MakeLower()) !=
+      architectures.end()) {
+    return false;
+  }
+
+  architectures.erase(
+      std::remove_if(architectures.begin(), architectures.end(),
+                     [](const CString& arch) { return arch[0] == '-'; }),
+      architectures.end());
+
+  return architectures.empty() ||
+         std::find_if(architectures.begin(), architectures.end(),
+                      SystemInfo::IsArchitectureSupported) !=
+             architectures.end();
 }
 
 bool IsOSVersionCompatible(const CString& min_os_version) {


### PR DESCRIPTION
For [brave-browser#32598](github.com/brave/brave-browser/issues/32598). We want to always install Arm64 Brave on Arm64 Windows, and never x64 Brave. The implementation is for the Omaha client to send the OS architecture to the update server, and the update server then returning a native binary.

The Omaha client already sent its architecture to the server before this PR. But when Omaha was running on Arm64, it still sent "x64" because it runs under WoW64 emulation.